### PR TITLE
Fix webcam autoplay to avoid stuck loading screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ npm start
 Once running, open your browser at `http://localhost:8080` (or the port you
 specified). Allow webcam access when prompted.
 
+### Troubleshooting
+If you see a blue screen with three loading dots, the webcam stream has not
+started. Confirm that the browser has permission to use the camera and check the
+terminal or browser console for debug logs.
+
 ## Development Notes
 - Set `PROD=true` when starting the server to log production mode.
 - Server and client log connection and debugging information to the terminal

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,12 @@
   <!-- Main A-Frame scene. Removing 'embedded' allows full-screen rendering -->
   <a-scene>
     <a-assets>
-      <video id="localVideo" autoplay playsinline></video>
+      <!--
+        Include the video element used for the local webcam feed. The `muted`
+        attribute ensures browsers allow autoplay which lets A-Frame finish
+        loading instead of leaving the user on the default blue loading screen.
+      -->
+      <video id="localVideo" autoplay playsinline muted></video>
     </a-assets>
 
     <!-- Simple floor and lighting -->

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -1,9 +1,16 @@
 // Client-side script for Mingle prototype
 // Captures webcam stream and sends avatar position to server for simple synchronization.
 
+// Establish socket connection to the server and cache DOM references.
 const socket = io();
 const avatar = document.getElementById('avatar');
 const cameraRig = document.getElementById('rig');
+
+// Log when the A-Frame scene has finished initialising which helps debug
+// stuck loading screens.
+document.querySelector('a-scene').addEventListener('loaded', () => {
+  console.log('A-Frame scene loaded');
+});
 
 // Debug: log connection status
 socket.on('connect', () => console.log('Connected to server', socket.id));
@@ -12,8 +19,18 @@ socket.on('connect', () => console.log('Connected to server', socket.id));
 navigator.mediaDevices.getUserMedia({ video: true, audio: false })
   .then(stream => {
     const videoEl = document.getElementById('localVideo');
+
+    // Attach the stream to the video element. Muting allows autoplay which
+    // prevents the A-Frame loader from stalling waiting for the video.
+    videoEl.muted = true;
     videoEl.srcObject = stream;
-    console.log('Webcam stream started');
+    videoEl.onloadeddata = () => console.log('Webcam video element loaded');
+
+    // Some browsers require an explicit play() call. Log success/failure for
+    // easier debugging.
+    videoEl.play()
+      .then(() => console.log('Webcam stream started'))
+      .catch(err => console.error('Webcam playback failed', err));
   })
   .catch(err => console.error('Could not start webcam', err));
 


### PR DESCRIPTION
## Summary
- prevent A-Frame loader hanging by muting webcam element
- add scene and webcam debug logs
- document troubleshooting for blue loading screen

## Testing
- `npm start`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891191d0364832896e70ad25ffe1411