### PR TITLE
Fix A-Frame initialisation and clean up client loading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,14 @@
       z-index: 100;
     }
   </style>
+  <!--
+    Load A-Frame and supporting libraries *before* the scene so that all
+    custom elements are registered when the HTML is parsed. The configuration
+    script exposes whether the server was launched in debug mode.
+  -->
+  <script src="https://aframe.io/releases/1.4.0/aframe.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/socket.io-client@4.7.2/dist/socket.io.min.js"></script>
+  <script src="/config.js"></script>
 </head>
 <body>
   <div id="instructions">
@@ -52,10 +60,7 @@
     </a-entity>
   </a-scene>
 
-  <!-- Configuration script exposes server side debug flag -->
-  <script src="/config.js"></script>
-  <script src="https://aframe.io/releases/1.4.0/aframe.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/socket.io-client@4.7.2/dist/socket.io.min.js"></script>
+  <!-- Client logic is loaded last once the DOM and libraries are ready -->
   <script src="js/mingle_client.js"></script>
 </body>
 </html>

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -40,8 +40,9 @@ navigator.mediaDevices.getUserMedia({ video: true, audio: false })
     videoEl.srcObject = stream;
     videoEl.onloadeddata = () => {
       debugLog('Webcam video element loaded');
-      // Ensure the scene is considered loaded once the video is ready.
-      sceneEl.emit('loaded');
+      // The scene is already visible because the default loading screen is
+      // disabled, so we avoid manually firing the 'loaded' event which could
+      // trigger A-Frame initialisation before its renderer is ready.
     };
 
     // Some browsers require an explicit play() call. Log success/failure for
@@ -51,11 +52,10 @@ navigator.mediaDevices.getUserMedia({ video: true, audio: false })
       .catch(err => debugError('Webcam playback failed', err));
   })
   .catch(err => {
-    // If the webcam cannot start, log the error (in debug mode), inform the
-    // user on-screen and force the scene to continue loading to avoid the
-    // perpetual blue loading screen.
+    // If the webcam cannot start, log the error (in debug mode) and inform the
+    // user on-screen. The scene still renders thanks to the disabled loading
+    // screen.
     debugError('Could not start webcam', err);
-    sceneEl.emit('loaded');
     document.getElementById('instructions').innerHTML +=
       '<p>Webcam unavailable. Check camera permissions.</p>';
   });


### PR DESCRIPTION
## Summary
- load A-Frame and related libs in the document head so the scene parses after components register
- avoid manually firing the scene `loaded` event to prevent renderer errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `PORT=3000 npm start -- --debug`

------
https://chatgpt.com/codex/tasks/task_e_689127e79f088328826ca60686c0bd98