### PR TITLE
feat: add https support and spectate mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ Mingle is an experimental 3D video meeting environment. Each attendee controls a
 first-person avatar whose face displays a live webcam feed.
 
 ## Features
-- WASD + mouse look movement in a simple 3D scene
+- WASD + mouse look movement with the camera pinned to the avatar centre
+- Toggleable spectate mode to view the scene from a fixed overhead camera
 - Webcam feed mapped onto the local avatar
 - Basic multi-user position synchronisation via Socket.io
 - Configurable port via `PORT` environment variable
+- Optional HTTPS support for secure contexts (`USE_HTTPS=true`)
 - Verbose logs for easy debugging
 - Optional `--debug` flag to surface additional diagnostic information
 
@@ -15,23 +17,38 @@ first-person avatar whose face displays a live webcam feed.
 
 ### Linux / Raspberry Pi
 ```bash
-./setup_mingle_env.sh
-PORT=8080 npm start
+./setup_mingle_env.sh                # install dependencies
+./create_mingle_cert.sh             # optional: create self-signed cert
+PORT=8080 npm start                 # run over HTTP
+# HTTPS example:
+# USE_HTTPS=true PORT=8443 npm start
 # Optional: add --debug for verbose console logging
-# PORT=8080 npm start -- --debug
+# USE_HTTPS=true PORT=8443 npm start -- --debug
 ```
 
 ### Windows (PowerShell)
 ```powershell
-./setup_mingle_env.ps1
+./setup_mingle_env.ps1               # install dependencies
+./create_mingle_cert.ps1             # optional: create self-signed cert
 $env:PORT=8080
-npm start
+npm start                            # run over HTTP
+# HTTPS example:
+# $env:USE_HTTPS="true"
+# $env:PORT=8443
+# npm start
 # Optional: add --debug for verbose console logging
 # npm start -- --debug
 ```
 
 Once running, open your browser at `http://localhost:8080` (or the port you
-specified). Allow webcam access when prompted.
+specified). Mobile browsers require HTTPS to access device sensors; generate the
+self-signed certificate and start with `USE_HTTPS=true` to enable it.
+
+> The certificate scripts use OpenSSL. Install it beforehand if it is not already available.
+
+### Controls
+- `WASD` to move, mouse to look around
+- Press `P` to toggle spectate mode
 
 ### Troubleshooting
 If you see a blue screen with three loading dots, the webcam stream has not

--- a/create_mingle_cert.ps1
+++ b/create_mingle_cert.ps1
@@ -1,0 +1,5 @@
+# PowerShell script to generate a self-signed certificate for the Mingle prototype.
+# Requires OpenSSL to be installed and available in the PATH.
+New-Item -ItemType Directory -Path certs -Force | Out-Null
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout certs/mingle.key -out certs/mingle.cert -subj "/CN=localhost"
+Write-Host "Certificate and key generated in certs\"

--- a/create_mingle_cert.sh
+++ b/create_mingle_cert.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Generates a self-signed certificate for the Mingle prototype.
+# Useful for enabling HTTPS which some mobile browsers require for sensor access.
+# Requires OpenSSL to be installed.
+set -e
+mkdir -p certs
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout certs/mingle.key -out certs/mingle.cert -subj "/CN=localhost"
+echo "Certificate and key generated in certs/"

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
 <body>
   <div id="instructions">
     <p>Use WASD to move and mouse to look.</p>
-    <p>Your webcam feed appears on your avatar.</p>
+    <p>Press P to toggle spectate mode.</p>
   </div>
 
   <!-- Main A-Frame scene. Removing 'embedded' allows full-screen rendering -->
@@ -51,13 +51,15 @@
     <a-entity light="type: ambient; intensity: 0.5"></a-entity>
     <a-entity light="type: directional; intensity: 0.8" position="0 1 1"></a-entity>
 
-    <!-- User avatar with video texture -->
-    <a-box id="avatar" position="0 1.6 0" width="1" height="1" depth="0.1" material="src:#localVideo"></a-box>
-
-    <!-- Camera rig for first-person movement -->
-    <a-entity id="rig" position="0 1.6 3">
-      <a-camera wasd-controls-enabled="true" look-controls="pointerLockEnabled: true"></a-camera>
+    <!-- Player entity that holds the camera and avatar. The avatar is hidden locally
+         so it does not obstruct the view but still moves for remote clients. -->
+    <a-entity id="player" position="0 1.6 0" wasd-controls="">
+      <a-camera id="playerCamera" look-controls="pointerLockEnabled: true"></a-camera>
+      <a-box id="avatar" position="0 0 0" width="1" height="1" depth="0.1" material="src:#localVideo" visible="false"></a-box>
     </a-entity>
+
+    <!-- Spectator camera fixed at a high corner for observing during tests -->
+    <a-camera id="spectateCam" position="5 8 5" rotation="-30 -45 0" visible="false"></a-camera>
   </a-scene>
 
   <!-- Client logic is loaded last once the DOM and libraries are ready -->


### PR DESCRIPTION
## Summary
- add optional HTTPS server with configurable certificate paths
- attach camera to avatar and introduce spectate mode toggle
- document HTTPS setup and controls, including self-signed cert scripts

## Testing
- `./create_mingle_cert.sh`
- `USE_HTTPS=true PORT=4443 node mingle_server.js --debug`

------
https://chatgpt.com/codex/tasks/task_e_68912d6170fc832891ddb3cc8c1df99a