### PR TITLE
Fix avatar video visibility and stabilize controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,10 +51,14 @@
     <a-entity light="type: ambient; intensity: 0.5"></a-entity>
     <a-entity light="type: directional; intensity: 0.8" position="0 1 1"></a-entity>
 
-    <!-- Player entity that holds the camera and avatar. The avatar is hidden locally
-         so it does not obstruct the view but still moves for remote clients. -->
-    <a-entity id="player" position="0 1.6 0" wasd-controls="">
-      <a-camera id="playerCamera" look-controls="pointerLockEnabled: true"></a-camera>
+    <!-- Player entity that holds the camera and avatar. Movement is handled by a
+         custom controller in mingle_client.js so we omit the built-in
+         `wasd-controls`. The avatar starts hidden so it does not obstruct the
+         first-person view but becomes visible in spectate mode. -->
+    <a-entity id="player" position="0 1.6 0">
+      <!-- Position the camera on the forward face of the avatar for a true
+           first-person perspective. -->
+      <a-camera id="playerCamera" position="0 0 -0.05" look-controls="pointerLockEnabled: true"></a-camera>
       <a-box id="avatar" position="0 0 0" width="1" height="1" depth="0.1" material="src:#localVideo" visible="false"></a-box>
     </a-entity>
 


### PR DESCRIPTION
## Summary
- handle WASD movement with a custom controller to avoid camera-dependent glitches
- show the local video-mapped avatar while spectating and move first-person camera to the avatar face

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689132f06600832883a1d46c635942f8