### PR TITLE
Refine first-person controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
 </head>
 <body>
   <div id="instructions">
-    <p>Use WASD to move and mouse to look.</p>
+    <p>Use WASD to move and mouse to look. Click to lock pointer.</p>
     <p>Press P to toggle spectate mode.</p>
   </div>
 
@@ -56,14 +56,16 @@
          `wasd-controls`. The avatar starts hidden so it does not obstruct the
          first-person view but becomes visible in spectate mode. -->
     <a-entity id="player" position="0 1.6 0">
-      <!-- Position the camera on the forward face of the avatar for a true
-           first-person perspective. -->
-      <a-camera id="playerCamera" position="0 0 -0.05" look-controls="pointerLockEnabled: true"></a-camera>
-      <a-box id="avatar" position="0 0 0" width="1" height="1" depth="0.1" material="src:#localVideo" visible="false"></a-box>
+      <!-- Position the camera exactly on the forward face of the avatar for a
+           true first-person perspective. The avatar is offset backwards so that
+           its textured face sits just behind the camera. -->
+      <a-camera id="playerCamera" position="0 0 0" look-controls="pointerLockEnabled: true"></a-camera>
+      <a-box id="avatar" position="0 0 0.05" width="1" height="1" depth="0.1" material="src:#localVideo" visible="false"></a-box>
     </a-entity>
 
-    <!-- Spectator camera fixed at a high corner for observing during tests -->
-    <a-camera id="spectateCam" position="5 8 5" rotation="-30 -45 0" visible="false"></a-camera>
+    <!-- Spectator camera fixed at the top corner with a wide field of view to
+         encompass the entire scene. -->
+    <a-camera id="spectateCam" position="10 10 10" rotation="-35 -45 0" fov="80" visible="false"></a-camera>
   </a-scene>
 
   <!-- Client logic is loaded last once the DOM and libraries are ready -->

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -56,6 +56,10 @@ function movementLoop(time) {
   const dt = (time - lastMove) / 1000;
   lastMove = time;
 
+  // Keep the player's rotation perfectly in sync with the camera so the avatar
+  // pitches and yaws exactly with mouse movement.
+  player.object3D.rotation.copy(playerCamera.object3D.rotation);
+
   const dir = new THREE.Vector3();
   if (keys.w) dir.z -= 1;
   if (keys.s) dir.z += 1;
@@ -64,8 +68,8 @@ function movementLoop(time) {
 
   if (dir.lengthSq() > 0) {
     dir.normalize();
-    // Apply the camera's current yaw to move relative to where the avatar faces
-    const yaw = playerCamera.object3D.rotation.y;
+    // Apply the player's current yaw so movement is relative to facing
+    const yaw = player.object3D.rotation.y;
     dir.applyEuler(new THREE.Euler(0, yaw, 0));
     player.object3D.position.addScaledVector(dir, MOVE_SPEED * dt);
   }
@@ -109,10 +113,9 @@ navigator.mediaDevices.getUserMedia({ video: true, audio: false })
 // driven by the camera's look-controls, so we copy that rotation onto the player
 // entity before broadcasting.
 setInterval(() => {
-  const camRotation = playerCamera.getAttribute('rotation');
-  player.setAttribute('rotation', camRotation);
   const position = player.getAttribute('position');
-  socket.emit('position', { position, rotation: camRotation });
+  const rotation = player.getAttribute('rotation');
+  socket.emit('position', { position, rotation });
 }, 100);
 
 // Toggle spectate mode by pressing 'p'. When enabled the main camera is switched


### PR DESCRIPTION
## Summary
- Place the first-person camera on the avatar's forward face and relocate the spectate camera to a fixed corner with a wide field of view.
- Sync player rotation with mouse look each frame for accurate FPS-style movement.
- Display on-screen reminder to click for pointer lock.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `PORT=3000 npm start` *(server starts and then is terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689136043f088328a64bd741dfb8d016