### PR TITLE
feat: add profile menu and placeholder pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ first-person avatar whose face displays a live webcam feed.
 - Optional HTTPS support for secure contexts (`USE_HTTPS=true`)
 - Verbose logs for easy debugging
 - Optional `--debug` flag to surface additional diagnostic information
+- Responsive navigation bar with profile menu linking to account management pages
 
 ## Quick Start
 

--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,52 @@
     /* Make the scene occupy the full viewport */
     html, body { width: 100%; height: 100%; margin: 0; font-family: Arial, sans-serif; }
     a-scene { width: 100%; height: 100%; }
+    /* Simple navigation bar anchored to the top of the page */
+    nav {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 50px;
+      background: #333;
+      color: #fff;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0 10px;
+      z-index: 200;
+    }
+    nav a { color: #fff; text-decoration: none; font-weight: bold; }
+    .profile-menu { position: relative; }
+    .profile-button {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      cursor: pointer;
+    }
+    .dropdown {
+      position: absolute;
+      right: 0;
+      top: 50px;
+      background: #fff;
+      color: #333;
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      border: 1px solid #ccc;
+      display: none;
+      min-width: 180px;
+    }
+    .dropdown li a {
+      display: block;
+      padding: 10px 15px;
+      color: #333;
+    }
+    .dropdown li a:hover { background: #f0f0f0; }
+    .dropdown.show { display: block; }
     #instructions {
       position: absolute;
-      top: 10px;
+      top: 60px;
       left: 10px;
       background: rgba(0,0,0,0.6);
       color: #fff;
@@ -28,9 +71,24 @@
   <script src="/config.js"></script>
 </head>
 <body>
+  <nav>
+    <div><a href="/index.html">Mingle</a></div>
+    <div class="profile-menu">
+      <img src="https://via.placeholder.com/40" alt="Profile" id="profileButton" class="profile-button" />
+      <ul id="profileDropdown" class="dropdown">
+        <li><a href="manage_profiles.html">Manage Profiles</a></li>
+        <li><a href="learning_zone.html">Learning Zone</a></li>
+        <li><a href="my_details.html">My Details</a></li>
+        <li><a href="subscription_details.html">Subscription Details</a></li>
+        <li><a href="manage_users.html">Manage Users</a></li>
+        <li><a href="#" id="signOut">Sign out</a></li>
+      </ul>
+    </div>
+  </nav>
   <div id="instructions">
     <p>Use WASD to move and mouse to look. Click to lock pointer.</p>
     <p>Press P to toggle spectate mode.</p>
+    <p>Use the profile button in the top-right to access account options.</p>
   </div>
 
   <!-- Main A-Frame scene. Removing 'embedded' allows full-screen rendering -->
@@ -70,5 +128,6 @@
 
   <!-- Client logic is loaded last once the DOM and libraries are ready -->
   <script src="js/mingle_client.js"></script>
+  <script src="js/mingle_navbar.js"></script>
 </body>
 </html>

--- a/public/js/mingle_navbar.js
+++ b/public/js/mingle_navbar.js
@@ -1,0 +1,27 @@
+// Navbar logic for Mingle prototype.
+// Handles profile menu toggling and sign-out behaviour with optional debug logs.
+
+// Helper debug logger to keep verbose output consistent across scripts.
+function navDebugLog(...args) {
+  if (window.MINGLE_DEBUG) {
+    console.log(...args);
+  }
+}
+
+// Toggle the profile dropdown when the profile image is clicked.
+const profileButton = document.getElementById('profileButton');
+const dropdown = document.getElementById('profileDropdown');
+profileButton.addEventListener('click', () => {
+  dropdown.classList.toggle('show');
+  navDebugLog('Profile menu toggled');
+});
+
+// Simple sign-out handler. In a real application this would clear session data
+// and redirect to a login screen.
+const signOutLink = document.getElementById('signOut');
+signOutLink.addEventListener('click', (e) => {
+  e.preventDefault();
+  navDebugLog('Sign out selected');
+  alert('You have been signed out.');
+  window.location.href = '/';
+});

--- a/public/learning_zone.html
+++ b/public/learning_zone.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Learning Zone - Mingle</title>
+  <style>
+    html, body { margin:0; font-family: Arial, sans-serif; }
+    nav { position:fixed; top:0; left:0; right:0; height:50px; background:#333; color:#fff; display:flex; justify-content:space-between; align-items:center; padding:0 10px; z-index:100; }
+    nav a { color:#fff; text-decoration:none; font-weight:bold; }
+    .profile-menu { position:relative; }
+    .profile-button { width:40px; height:40px; border-radius:20px; cursor:pointer; }
+    .dropdown { position:absolute; right:0; top:50px; background:#fff; color:#333; list-style:none; padding:0; margin:0; border:1px solid #ccc; display:none; min-width:180px; }
+    .dropdown li a { display:block; padding:10px 15px; color:#333; }
+    .dropdown li a:hover { background:#f0f0f0; }
+    .dropdown.show { display:block; }
+    main { padding:70px 10px; }
+  </style>
+  <script src="/config.js"></script>
+</head>
+<body>
+  <nav>
+    <div><a href="/index.html">Mingle</a></div>
+    <div class="profile-menu">
+      <img src="https://via.placeholder.com/40" alt="Profile" id="profileButton" class="profile-button" />
+      <ul id="profileDropdown" class="dropdown">
+        <li><a href="manage_profiles.html">Manage Profiles</a></li>
+        <li><a href="learning_zone.html">Learning Zone</a></li>
+        <li><a href="my_details.html">My Details</a></li>
+        <li><a href="subscription_details.html">Subscription Details</a></li>
+        <li><a href="manage_users.html">Manage Users</a></li>
+        <li><a href="#" id="signOut">Sign out</a></li>
+      </ul>
+    </div>
+  </nav>
+  <main>
+    <h1>Learning Zone</h1>
+    <p>Access tutorials and guides in the Learning Zone. Use the profile menu to return to the main scene or visit other sections.</p>
+  </main>
+  <script src="js/mingle_navbar.js"></script>
+</body>
+</html>

--- a/public/manage_profiles.html
+++ b/public/manage_profiles.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Manage Profiles - Mingle</title>
+  <style>
+    /* Basic page and navbar styling shared across simple screens */
+    html, body { margin:0; font-family: Arial, sans-serif; }
+    nav {
+      position: fixed; top:0; left:0; right:0; height:50px;
+      background:#333; color:#fff; display:flex;
+      justify-content: space-between; align-items:center;
+      padding:0 10px; z-index:100;
+    }
+    nav a { color:#fff; text-decoration:none; font-weight:bold; }
+    .profile-menu { position:relative; }
+    .profile-button { width:40px; height:40px; border-radius:20px; cursor:pointer; }
+    .dropdown { position:absolute; right:0; top:50px; background:#fff; color:#333; list-style:none; padding:0; margin:0; border:1px solid #ccc; display:none; min-width:180px; }
+    .dropdown li a { display:block; padding:10px 15px; color:#333; }
+    .dropdown li a:hover { background:#f0f0f0; }
+    .dropdown.show { display:block; }
+    main { padding:70px 10px; }
+  </style>
+  <script src="/config.js"></script>
+</head>
+<body>
+  <!-- Reusable navigation bar with profile menu -->
+  <nav>
+    <div><a href="/index.html">Mingle</a></div>
+    <div class="profile-menu">
+      <img src="https://via.placeholder.com/40" alt="Profile" id="profileButton" class="profile-button" />
+      <ul id="profileDropdown" class="dropdown">
+        <li><a href="manage_profiles.html">Manage Profiles</a></li>
+        <li><a href="learning_zone.html">Learning Zone</a></li>
+        <li><a href="my_details.html">My Details</a></li>
+        <li><a href="subscription_details.html">Subscription Details</a></li>
+        <li><a href="manage_users.html">Manage Users</a></li>
+        <li><a href="#" id="signOut">Sign out</a></li>
+      </ul>
+    </div>
+  </nav>
+  <main>
+    <h1>Manage Profiles</h1>
+    <p>Update your profile information here. Use the menu to access other sections or return to the main scene.</p>
+  </main>
+  <script src="js/mingle_navbar.js"></script>
+</body>
+</html>

--- a/public/manage_users.html
+++ b/public/manage_users.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Manage Users - Mingle</title>
+  <style>
+    html, body { margin:0; font-family: Arial, sans-serif; }
+    nav { position:fixed; top:0; left:0; right:0; height:50px; background:#333; color:#fff; display:flex; justify-content:space-between; align-items:center; padding:0 10px; z-index:100; }
+    nav a { color:#fff; text-decoration:none; font-weight:bold; }
+    .profile-menu { position:relative; }
+    .profile-button { width:40px; height:40px; border-radius:20px; cursor:pointer; }
+    .dropdown { position:absolute; right:0; top:50px; background:#fff; color:#333; list-style:none; padding:0; margin:0; border:1px solid #ccc; display:none; min-width:180px; }
+    .dropdown li a { display:block; padding:10px 15px; color:#333; }
+    .dropdown li a:hover { background:#f0f0f0; }
+    .dropdown.show { display:block; }
+    main { padding:70px 10px; }
+  </style>
+  <script src="/config.js"></script>
+</head>
+<body>
+  <nav>
+    <div><a href="/index.html">Mingle</a></div>
+    <div class="profile-menu">
+      <img src="https://via.placeholder.com/40" alt="Profile" id="profileButton" class="profile-button" />
+      <ul id="profileDropdown" class="dropdown">
+        <li><a href="manage_profiles.html">Manage Profiles</a></li>
+        <li><a href="learning_zone.html">Learning Zone</a></li>
+        <li><a href="my_details.html">My Details</a></li>
+        <li><a href="subscription_details.html">Subscription Details</a></li>
+        <li><a href="manage_users.html">Manage Users</a></li>
+        <li><a href="#" id="signOut">Sign out</a></li>
+      </ul>
+    </div>
+  </nav>
+  <main>
+    <h1>Manage Users</h1>
+    <p>Control user access and permissions from this screen. Use the profile menu to explore other areas or return to the main scene.</p>
+  </main>
+  <script src="js/mingle_navbar.js"></script>
+</body>
+</html>

--- a/public/my_details.html
+++ b/public/my_details.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>My Details - Mingle</title>
+  <style>
+    html, body { margin:0; font-family: Arial, sans-serif; }
+    nav { position:fixed; top:0; left:0; right:0; height:50px; background:#333; color:#fff; display:flex; justify-content:space-between; align-items:center; padding:0 10px; z-index:100; }
+    nav a { color:#fff; text-decoration:none; font-weight:bold; }
+    .profile-menu { position:relative; }
+    .profile-button { width:40px; height:40px; border-radius:20px; cursor:pointer; }
+    .dropdown { position:absolute; right:0; top:50px; background:#fff; color:#333; list-style:none; padding:0; margin:0; border:1px solid #ccc; display:none; min-width:180px; }
+    .dropdown li a { display:block; padding:10px 15px; color:#333; }
+    .dropdown li a:hover { background:#f0f0f0; }
+    .dropdown.show { display:block; }
+    main { padding:70px 10px; }
+  </style>
+  <script src="/config.js"></script>
+</head>
+<body>
+  <nav>
+    <div><a href="/index.html">Mingle</a></div>
+    <div class="profile-menu">
+      <img src="https://via.placeholder.com/40" alt="Profile" id="profileButton" class="profile-button" />
+      <ul id="profileDropdown" class="dropdown">
+        <li><a href="manage_profiles.html">Manage Profiles</a></li>
+        <li><a href="learning_zone.html">Learning Zone</a></li>
+        <li><a href="my_details.html">My Details</a></li>
+        <li><a href="subscription_details.html">Subscription Details</a></li>
+        <li><a href="manage_users.html">Manage Users</a></li>
+        <li><a href="#" id="signOut">Sign out</a></li>
+      </ul>
+    </div>
+  </nav>
+  <main>
+    <h1>My Details</h1>
+    <p>View and edit your personal details here. Use the profile menu to navigate to other sections.</p>
+  </main>
+  <script src="js/mingle_navbar.js"></script>
+</body>
+</html>

--- a/public/subscription_details.html
+++ b/public/subscription_details.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Subscription Details - Mingle</title>
+  <style>
+    html, body { margin:0; font-family: Arial, sans-serif; }
+    nav { position:fixed; top:0; left:0; right:0; height:50px; background:#333; color:#fff; display:flex; justify-content:space-between; align-items:center; padding:0 10px; z-index:100; }
+    nav a { color:#fff; text-decoration:none; font-weight:bold; }
+    .profile-menu { position:relative; }
+    .profile-button { width:40px; height:40px; border-radius:20px; cursor:pointer; }
+    .dropdown { position:absolute; right:0; top:50px; background:#fff; color:#333; list-style:none; padding:0; margin:0; border:1px solid #ccc; display:none; min-width:180px; }
+    .dropdown li a { display:block; padding:10px 15px; color:#333; }
+    .dropdown li a:hover { background:#f0f0f0; }
+    .dropdown.show { display:block; }
+    main { padding:70px 10px; }
+  </style>
+  <script src="/config.js"></script>
+</head>
+<body>
+  <nav>
+    <div><a href="/index.html">Mingle</a></div>
+    <div class="profile-menu">
+      <img src="https://via.placeholder.com/40" alt="Profile" id="profileButton" class="profile-button" />
+      <ul id="profileDropdown" class="dropdown">
+        <li><a href="manage_profiles.html">Manage Profiles</a></li>
+        <li><a href="learning_zone.html">Learning Zone</a></li>
+        <li><a href="my_details.html">My Details</a></li>
+        <li><a href="subscription_details.html">Subscription Details</a></li>
+        <li><a href="manage_users.html">Manage Users</a></li>
+        <li><a href="#" id="signOut">Sign out</a></li>
+      </ul>
+    </div>
+  </nav>
+  <main>
+    <h1>Subscription Details</h1>
+    <p>Review your subscription information on this page. Use the profile menu to manage other settings or return to the main scene.</p>
+  </main>
+  <script src="js/mingle_navbar.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add top-right profile menu with navigation options and sign-out handler
- provide placeholder pages for profile management, learning zone, details, subscription, and user management
- document new navigation feature in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689207cbe7bc8328a92f31c5a2a4ef6e