### PR TITLE
Render webcam only on avatar front face

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ first-person avatar whose face displays a live webcam feed.
 ## Features
 - WASD + mouse look movement with the camera pinned to the avatar centre
 - Toggleable spectate mode to view the scene from a fixed overhead camera
-- Webcam feed mapped onto the local avatar
+- Webcam feed mapped onto the front face of the local avatar
 - Basic multi-user position synchronisation via Socket.io
 - Configurable port via `PORT` environment variable
 - Optional HTTPS support for secure contexts (`USE_HTTPS=true`)

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     1. Page styling and navigation bar
     2. On-screen usage instructions
     3. Camera control sidebar with real-time status
-    4. A-Frame scene setup with assets, cameras and avatar
+    4. A-Frame scene setup with assets, cameras and avatar (webcam only on front face)
     5. Client scripts for movement and navbar functionality
   - Notes: A-Frame's default WASD controls are disabled on all cameras so that
     movement is handled exclusively by custom code in mingle_client.js.
@@ -156,11 +156,15 @@
          `wasd-controls`. The avatar starts hidden so it does not obstruct the
          first-person view but becomes visible in spectate mode. -->
     <a-entity id="player" position="0 1.6 0">
-      <!-- Position the camera exactly on the forward face of the avatar for a
-           true first-person perspective. The avatar is offset backwards so that
-           its textured face sits just behind the camera. -->
+      <!-- The avatar consists of a front-facing plane that displays the webcam
+           feed and a rear backing plane so the video only appears on the face
+           pointing in the camera direction. The camera itself sits at the
+           origin, directly behind the avatar's front face. -->
       <a-camera id="playerCamera" position="0 0 0" look-controls="pointerLockEnabled: true" wasd-controls="enabled: false"></a-camera>
-      <a-box id="avatar" position="0 0 0.05" width="1" height="1" depth="0.1" material="src:#localVideo" visible="false"></a-box>
+      <a-entity id="avatar" position="0 0 0.05" visible="false">
+        <a-plane id="avatarFront" width="1" height="1" material="src:#localVideo" position="0 0 0.05"></a-plane>
+        <a-plane id="avatarBack" width="1" height="1" color="#FFFFFF" position="0 0 -0.05" rotation="0 180 0"></a-plane>
+      </a-entity>
     </a-entity>
 
     <!-- Spectator camera fixed at the top corner with a wide field of view to


### PR DESCRIPTION
## Summary
- Prevent webcam video from texturing all avatar faces by splitting the avatar into a front plane for the feed and a backing plane for the rear
- Note in documentation that the video feed appears only on the avatar's front face

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689506ee37408328aaeae5524ba67726