### PR TITLE
Fix spectator mouse control and FPV axis handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -167,9 +167,11 @@
       </a-entity>
     </a-entity>
 
-    <!-- Spectator camera fixed at the top corner with a wide field of view to
-         encompass the entire scene. -->
-    <a-camera id="spectateCam" position="10 10 10" rotation="-35 -45 0" fov="80" visible="false" wasd-controls="enabled: false"></a-camera>
+    <!-- Spectator camera fixed at the top corner with its own look-controls so
+         mouse movement works independently of the first-person view. -->
+    <a-camera id="spectateCam" position="10 10 10" rotation="-35 -45 0" fov="80"
+              visible="false" wasd-controls="enabled: false"
+              look-controls="pointerLockEnabled: true"></a-camera>
   </a-scene>
 
   <!-- Client logic is loaded last once the DOM and libraries are ready -->


### PR DESCRIPTION
## Summary
- Add dedicated look-controls to spectator camera and manage component lifecycle when toggling modes
- Prevent compounded rotations by mirroring active camera orientation onto avatar only
- Send orientation based on active camera to keep remote avatars aligned

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689507fc7b648328972ce06f704d4e64