### PR TITLE
Fix avatar orientation and multi-user sync

### DIFF
--- a/mingle_server.js
+++ b/mingle_server.js
@@ -72,8 +72,10 @@ io.on('connection', (socket) => {
 
   // Forward position data to all clients
   socket.on('position', (data) => {
-    // Echo the data to other clients to keep avatars in sync.
-    socket.broadcast.emit('position', { id: socket.id, ...data });
+    // Echo the data to every client, including the sender. Clients ignore
+    // updates from themselves, ensuring that all connected participants are
+    // aware of each other's avatars even if they connect later.
+    io.emit('position', { id: socket.id, ...data });
     if (DEBUG) {
       console.log(`Position from ${socket.id}:`, data);
     }

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,8 @@
     2. On-screen usage instructions
     3. Camera control sidebar with real-time status
     4. A-Frame scene setup with assets, cameras, avatar and spectate marker
-       (webcam only on front face)
+       (webcam only on front face; remote avatars mirror this layout with a
+       placeholder colour until video streaming is available)
     5. Client scripts for movement and navbar functionality
   - Notes: A-Frame's default WASD controls are disabled on all cameras so that
     movement is handled exclusively by custom code in mingle_client.js.
@@ -158,13 +159,15 @@
     <a-entity id="player" position="0 1.6 0">
       <!-- The avatar consists of a front-facing plane that displays the webcam
            feed and a rear backing plane so the video only appears on the face
-           pointing in the camera direction. The camera itself sits at the
-           origin, directly behind the avatar's front face. -->
+           pointing in the camera direction. Remote participants are rendered
+           on every client by duplicating this front/back layout; their video
+           plane currently uses a placeholder colour until streaming is wired
+           up. The camera itself sits at the origin, directly behind the avatar's
+           front face. -->
       <a-camera id="playerCamera" position="0 0 0" look-controls="pointerLockEnabled: true" wasd-controls="enabled: false"></a-camera>
       <!-- Position the avatar directly in front of the player camera. The video
-           plane is rotated to face the same direction as the player so remote
-           viewers see the webcam on the front of the avatar rather than the
-           back. -->
+           plane is rotated to face the same direction as the player so all
+           clients view the webcam on the avatar's front rather than the back. -->
       <a-entity id="avatar" position="0 0 0" visible="false">
         <a-plane id="avatarFront" width="1" height="1" material="src:#localVideo" position="0 0 -0.05" rotation="0 180 0"></a-plane>
         <a-plane id="avatarBack" width="1" height="1" color="#FFFFFF" position="0 0 0.05"></a-plane>

--- a/public/index.html
+++ b/public/index.html
@@ -161,9 +161,13 @@
            pointing in the camera direction. The camera itself sits at the
            origin, directly behind the avatar's front face. -->
       <a-camera id="playerCamera" position="0 0 0" look-controls="pointerLockEnabled: true" wasd-controls="enabled: false"></a-camera>
-      <a-entity id="avatar" position="0 0 0.05" visible="false">
-        <a-plane id="avatarFront" width="1" height="1" material="src:#localVideo" position="0 0 0.05"></a-plane>
-        <a-plane id="avatarBack" width="1" height="1" color="#FFFFFF" position="0 0 -0.05" rotation="0 180 0"></a-plane>
+      <!-- Position the avatar directly in front of the player camera. The video
+           plane is rotated to face the same direction as the player so remote
+           viewers see the webcam on the front of the avatar rather than the
+           back. -->
+      <a-entity id="avatar" position="0 0 0" visible="false">
+        <a-plane id="avatarFront" width="1" height="1" material="src:#localVideo" position="0 0 -0.05" rotation="0 180 0"></a-plane>
+        <a-plane id="avatarBack" width="1" height="1" color="#FFFFFF" position="0 0 0.05"></a-plane>
       </a-entity>
     </a-entity>
 

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -267,23 +267,42 @@ socket.on('position', data => {
 
   let remote = remotes[data.id];
   if (!remote) {
-    const avatarBox = document.createElement('a-box');
-    avatarBox.setAttribute('color', data.color || '#888888');
-    avatarBox.setAttribute('width', 1);
-    avatarBox.setAttribute('height', 1);
-    avatarBox.setAttribute('depth', 0.1);
+    // Create an entity that mirrors the structure of the local #avatar with
+    // a front-facing video plane and a white backing plane.
+    const avatarEntity = document.createElement('a-entity');
+
+    const front = document.createElement('a-plane');
+    front.setAttribute('width', 1);
+    front.setAttribute('height', 1);
+    front.setAttribute('position', '0 0 -0.05');
+    front.setAttribute('rotation', '0 180 0');
+    // Remote video streams are not yet implemented, so use a grey placeholder
+    // colour until a real texture can be applied.
+    front.setAttribute('color', '#888888');
+
+    const back = document.createElement('a-plane');
+    back.setAttribute('width', 1);
+    back.setAttribute('height', 1);
+    back.setAttribute('position', '0 0 0.05');
+    back.setAttribute('color', '#FFFFFF');
+
+    avatarEntity.appendChild(front);
+    avatarEntity.appendChild(back);
+
     const camBox = document.createElement('a-box');
     camBox.setAttribute('color', data.color || '#888888');
     camBox.setAttribute('width', 0.5);
     camBox.setAttribute('height', 0.5);
     camBox.setAttribute('depth', 0.5);
     camBox.setAttribute('visible', false);
-    sceneEl.appendChild(avatarBox);
+
+    sceneEl.appendChild(avatarEntity);
     sceneEl.appendChild(camBox);
-    remotes[data.id] = { avatar: avatarBox, cam: camBox };
+    remotes[data.id] = { avatar: avatarEntity, cam: camBox };
     remote = remotes[data.id];
     debugLog('Remote avatar created for', data.id);
   }
+
   remote.avatar.setAttribute('position', data.position);
   remote.avatar.setAttribute('rotation', data.rotation);
   if (data.spectatePos) {

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -260,6 +260,11 @@ setInterval(() => {
 // Track remote avatars and their spectate camera markers
 const remotes = {};
 socket.on('position', data => {
+  // The server now echoes position updates to every client, including the
+  // sender. Ignore messages originating from this client so we only render
+  // avatars for other participants.
+  if (data.id === socket.id) { return; }
+
   let remote = remotes[data.id];
   if (!remote) {
     const avatarBox = document.createElement('a-box');
@@ -277,6 +282,7 @@ socket.on('position', data => {
     sceneEl.appendChild(camBox);
     remotes[data.id] = { avatar: avatarBox, cam: camBox };
     remote = remotes[data.id];
+    debugLog('Remote avatar created for', data.id);
   }
   remote.avatar.setAttribute('position', data.position);
   remote.avatar.setAttribute('rotation', data.rotation);

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -10,7 +10,8 @@
  *   4. Custom WASD movement handler and real-time status
  *   5. Webcam capture and playback
  *   6. Periodic server synchronisation
- *   7. Remote avatar and spectate marker tracking
+ *   7. Remote avatar and spectate marker tracking (mirrors local avatar with
+ *      placeholder video for other participants)
  */
 
 // Establish socket connection to the server and cache DOM references.
@@ -257,28 +258,28 @@ setInterval(() => {
   socket.emit('position', { position, rotation, color: playerColor, spectatePos });
 }, 100);
 
-// Track remote avatars and their spectate camera markers
+// Track remote avatars and their spectate camera markers. Each entry mirrors a
+// participant in the scene so everyone sees all other users.
 const remotes = {};
 socket.on('position', data => {
-  // The server now echoes position updates to every client, including the
-  // sender. Ignore messages originating from this client so we only render
-  // avatars for other participants.
+  // The server echoes position updates to every client, including the sender.
+  // Skip our own entry so only other participants generate remote avatars.
   if (data.id === socket.id) { return; }
 
   let remote = remotes[data.id];
   if (!remote) {
-    // Create an entity that mirrors the structure of the local #avatar with
-    // a front-facing video plane and a white backing plane.
+    // Remote avatars replicate the local #avatar: a forward-facing plane that
+    // would display the participant's video stream and a white backing plane
+    // so the texture only appears on the front. Video streaming for remotes is
+    // not yet wired up, so we use a grey placeholder colour instead.
     const avatarEntity = document.createElement('a-entity');
 
     const front = document.createElement('a-plane');
     front.setAttribute('width', 1);
     front.setAttribute('height', 1);
     front.setAttribute('position', '0 0 -0.05');
-    front.setAttribute('rotation', '0 180 0');
-    // Remote video streams are not yet implemented, so use a grey placeholder
-    // colour until a real texture can be applied.
-    front.setAttribute('color', '#888888');
+    front.setAttribute('rotation', '0 180 0'); // face the same direction as the avatar
+    front.setAttribute('color', '#888888'); // placeholder until remote video is streamed
 
     const back = document.createElement('a-plane');
     back.setAttribute('width', 1);


### PR DESCRIPTION
## Summary
- Ensure webcam video plane faces the correct direction on the avatar so the feed renders on the front.
- Broadcast position data to all clients and ignore self-updates on the client to render avatars for every participant.
- Add debug logging when creating remote avatars.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node mingle_server.js --debug`

------
https://chatgpt.com/codex/tasks/task_e_68962ad116a483288616a1d37171618d