### PR TITLE
feat: add world selection menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ first-person avatar whose face displays a live webcam feed.
 - Verbose logs for easy debugging
 - Optional `--debug` flag to surface additional diagnostic information
 - Responsive navigation bar with profile menu linking to account management pages
+- World selection menu on startup to choose environment
 
 ## Quick Start
 

--- a/mingle_server.js
+++ b/mingle_server.js
@@ -6,7 +6,7 @@
  *   1. Configuration flags (port, host, HTTPS, debug)
  *   2. Server creation (HTTP/HTTPS)
  *   3. Static routes and config endpoint
- *   4. Socket.io events for position updates
+ *   4. Socket.io events for position updates and world selection
  *   5. Startup logging with LAN-friendly addresses
  * - Notes: set HOST=0.0.0.0 to allow LAN clients. Use --debug for verbose logs.
  */
@@ -69,6 +69,17 @@ io.on('connection', (socket) => {
   // Always log client connections. Additional details are logged when in
   // debug mode to aid troubleshooting networking issues.
   console.log(`Client connected: ${socket.id}`);
+
+  // Record which world the client wishes to join.
+  socket.on('joinWorld', (world) => {
+    if (typeof world !== 'string') {
+      return; // Ignore malformed input.
+    }
+    socket.world = world;
+    if (DEBUG) {
+      console.log(`Client ${socket.id} joined world ${world}`);
+    }
+  });
 
   // Forward position data to all clients
   socket.on('position', (data) => {

--- a/public/index.html
+++ b/public/index.html
@@ -4,13 +4,14 @@
   Mini README:
   - Purpose: renders the main 3D meeting interface and surrounding UI chrome.
   - Structure:
-    1. Page styling and navigation bar
-    2. On-screen usage instructions
-    3. Camera control sidebar with real-time status
-    4. A-Frame scene setup with assets, cameras, avatar and spectate marker
+    1. Initial world selection overlay
+    2. Page styling and navigation bar
+    3. On-screen usage instructions
+    4. Camera control sidebar with real-time status
+    5. A-Frame scene setup with assets, cameras, avatar and spectate marker
        (webcam only on front face; remote avatars mirror this layout with a
        placeholder colour until video streaming is available)
-    5. Client scripts for movement and navbar functionality
+    6. Client scripts for movement and navbar functionality
   - Notes: A-Frame's default WASD controls are disabled on all cameras so that
     movement is handled exclusively by custom code in mingle_client.js.
 -->
@@ -66,6 +67,26 @@
     }
     .dropdown li a:hover { background: #f0f0f0; }
     .dropdown.show { display: block; }
+    /* Full-screen overlay prompting the user to choose a world */
+    #worldMenu {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.8);
+      color: #fff;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      z-index: 300;
+    }
+    #worldMenu select,
+    #worldMenu button {
+      margin-top: 10px;
+      padding: 8px;
+    }
     #instructions {
       position: absolute;
       top: 60px;
@@ -117,6 +138,15 @@
       </ul>
     </div>
   </nav>
+  <div id="worldMenu">
+    <h2>Select a world to enter</h2>
+    <select id="worldSelect">
+      <option value="lobby">Lobby</option>
+      <option value="auditorium">Auditorium</option>
+      <option value="garden">Garden</option>
+    </select>
+    <button id="enterWorld">Enter</button>
+  </div>
   <div id="instructions">
     <p>Use WASD to move and mouse to look. Click to lock pointer.</p>
     <p>Use the sidebar to switch spectate mode and choose fixed viewpoints (P also toggles spectate).</p>

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -4,13 +4,14 @@
  * - Purpose: client-side logic for the Mingle prototype. Handles local avatar
  *   movement, webcam streaming, and position synchronisation with the server.
  * - Structure:
- *   1. Socket and DOM initialisation (including unique player colour)
- *   2. Debug logging helpers
- *   3. UI controls for spectating and fixed camera viewpoints
- *   4. Custom WASD movement handler and real-time status
- *   5. Webcam capture and playback
- *   6. Periodic server synchronisation
- *   7. Remote avatar and spectate marker tracking (mirrors local avatar with
+ *   1. Socket and DOM initialisation (including world menu and unique player colour)
+ *   2. World selection menu handling
+ *   3. Debug logging helpers
+ *   4. UI controls for spectating and fixed camera viewpoints
+ *   5. Custom WASD movement handler and real-time status
+ *   6. Webcam capture and playback
+ *   7. Periodic server synchronisation
+ *   8. Remote avatar and spectate marker tracking (mirrors local avatar with
  *      placeholder video for other participants)
  */
 
@@ -25,8 +26,29 @@ const spectateMarker = document.getElementById('spectateMarker');
 const spectateToggle = document.getElementById('spectateToggle');
 const statusEl = document.getElementById('status');
 const viewpointRadios = document.querySelectorAll('input[name="viewpoint"]');
+const worldMenu = document.getElementById('worldMenu');
+const worldSelect = document.getElementById('worldSelect');
+const enterWorldBtn = document.getElementById('enterWorld');
 // Track which camera is currently rendering the view for status display.
 let activeCamera = playerCamera;
+
+// ---------------------------------------------------------------------------
+// World selection menu handling
+// ---------------------------------------------------------------------------
+const ALLOWED_WORLDS = ['lobby', 'auditorium', 'garden'];
+let currentWorld = null;
+enterWorldBtn.addEventListener('click', () => {
+  const chosen = worldSelect.value;
+  if (!ALLOWED_WORLDS.includes(chosen)) {
+    // Defensive check: ignore unexpected values.
+    debugError('Invalid world selected', chosen);
+    return;
+  }
+  currentWorld = chosen;
+  worldMenu.style.display = 'none';
+  debugLog('World selected:', currentWorld);
+  socket.emit('joinWorld', currentWorld);
+});
 
 // Assign a unique colour to this player used for the avatar's back and the
 // spectate marker. This colour is shared with other clients via socket updates.


### PR DESCRIPTION
## Summary
- add startup world selection overlay
- send chosen world to server and log join events
- document world selection feature in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68970df6c9248328bf3fff229c819550