### PR TITLE
Add entry mode selection with FPV, Spectator and Lakitu views

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Mingle is an experimental 3D video meeting environment. Each attendee controls a
 first-person avatar whose face displays a live webcam feed.
 
 ## Features
+- Start menu offering FPV, Spectator and Lakitu viewing modes
 - WASD + mouse look movement with the camera pinned to the avatar centre
 - Toggleable spectate mode to view the scene from a fixed overhead camera
 - Webcam feed mapped onto the front face of the local avatar
@@ -50,8 +51,9 @@ self-signed certificate and start with `USE_HTTPS=true` to enable it.
 > The certificate scripts use OpenSSL. Install it beforehand if it is not already available.
 
 ### Controls
+- Choose FPV, Spectator or Lakitu from the start menu
 - `WASD` to move, mouse to look around
-- Press `P` to toggle spectate mode
+- Press `P` to toggle spectate mode (not available in Lakitu mode)
 
 ### Troubleshooting
 If you see a blue screen with three loading dots, the webcam stream has not

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
   - Purpose: renders the main 3D meeting interface and surrounding UI chrome.
   - Structure:
     1. Page styling and navigation bar
-    2. On-screen usage instructions
+    2. Entry mode menu and on-screen usage instructions
     3. Camera control sidebar with real-time status
     4. A-Frame scene setup with assets, cameras, avatar and spectate marker
        (webcam only on front face; remote avatars mirror this layout with a
@@ -92,6 +92,24 @@
       font-size: 12px;
       color: #333;
     }
+    /* Simple start menu allowing users to choose their entry mode */
+    #modeMenu {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: rgba(255,255,255,0.95);
+      border: 1px solid #ccc;
+      padding: 20px;
+      z-index: 250;
+      text-align: center;
+    }
+    #modeMenu.hidden { display: none; }
+    #modeMenu button {
+      margin: 0 5px;
+      padding: 10px 15px;
+      cursor: pointer;
+    }
   </style>
   <!--
     Load A-Frame and supporting libraries *before* the scene so that all
@@ -117,9 +135,15 @@
       </ul>
     </div>
   </nav>
+  <!-- Initial mode selection menu displayed before entering the world -->
+  <div id="modeMenu">
+    <p>Select how to enter the world:</p>
+    <button data-mode="fpv">FPV mode</button>
+    <button data-mode="spectator">Spectator mode</button>
+    <button data-mode="lakitu">Lakitu mode</button>
+  </div>
   <div id="instructions">
-    <p>Use WASD to move and mouse to look. Click to lock pointer.</p>
-    <p>Use the sidebar to switch spectate mode and choose fixed viewpoints (P also toggles spectate).</p>
+    <p>Choose a mode, then use WASD to move and mouse to look. Click to lock pointer.</p>
     <p>Use the profile button in the top-right to access account options.</p>
   </div>
 


### PR DESCRIPTION
## Summary
- add on-load mode selection menu with FPV, Spectator and Lakitu tabs
- implement mode-specific camera behaviour and movement logic
- document new viewing modes and controls in README

## Testing
- `node --check public/js/mingle_client.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68972d46515083289a1f9a1798796e9f