### PR TITLE
use LISTEN_HOST env var to allow LAN clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ first-person avatar whose face displays a live webcam feed.
 - Webcam feed mapped onto the front face of the local avatar
 - Basic multi-user position synchronisation via Socket.io
 - Configurable port via `PORT` environment variable
+- Configurable host via `LISTEN_HOST` environment variable
 - Optional HTTPS support for secure contexts (`USE_HTTPS=true`)
 - Verbose logs for easy debugging
 - Optional `--debug` flag to surface additional diagnostic information
@@ -21,7 +22,7 @@ first-person avatar whose face displays a live webcam feed.
 ```bash
 ./setup_mingle_env.sh                # install dependencies
 ./create_mingle_cert.sh             # optional: create self-signed cert
-HOST=0.0.0.0 PORT=8080 npm start     # run over HTTP and allow LAN clients
+LISTEN_HOST=0.0.0.0 PORT=8080 npm start  # run over HTTP and allow LAN clients
 # HTTPS example:
 # USE_HTTPS=true PORT=8443 npm start
 # Optional: add --debug for verbose console logging
@@ -32,7 +33,7 @@ HOST=0.0.0.0 PORT=8080 npm start     # run over HTTP and allow LAN clients
 ```powershell
 ./setup_mingle_env.ps1               # install dependencies
 ./create_mingle_cert.ps1             # optional: create self-signed cert
-$env:HOST="0.0.0.0"
+$env:LISTEN_HOST="0.0.0.0"
 $env:PORT=8080
 npm start                            # run over HTTP and allow LAN clients
 # HTTPS example:

--- a/mingle_server.js
+++ b/mingle_server.js
@@ -8,7 +8,7 @@
  *   3. Static routes and config endpoint
  *   4. Socket.io events for position updates
  *   5. Startup logging with LAN-friendly addresses
- * - Notes: set HOST=0.0.0.0 to allow LAN clients. Use --debug for verbose logs.
+ * - Notes: set LISTEN_HOST=0.0.0.0 to allow LAN clients. Use --debug for verbose logs.
  */
 const express = require('express');
 const fs = require('fs');
@@ -18,10 +18,12 @@ const path = require('path');
 const os = require('os');
 const { Server } = require('socket.io');
 
-// Port and host are configurable via environment variables.
+// Port and host are configurable via environment variables. LISTEN_HOST is used
+// rather than HOST to avoid clashing with shells that define HOST by default
+// (which can inadvertently bind the server to an unreachable address).
 // Default host 0.0.0.0 exposes the server on all network interfaces.
 const PORT = process.env.PORT || 3000;
-const HOST = process.env.HOST || '0.0.0.0';
+const HOST = process.env.LISTEN_HOST || '0.0.0.0';
 const PROD = process.env.PROD === 'true';
 // Enable HTTPS by setting USE_HTTPS=true and providing certificate paths
 const USE_HTTPS = process.env.USE_HTTPS === 'true';


### PR DESCRIPTION
## Summary
- avoid accidental HOST collision by using LISTEN_HOST for the bind address
- document LISTEN_HOST in quick-start instructions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68973a193a3c8328a31663493633e4d6