### PR TITLE
refactor: generate certs without openssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The client will display a warning banner whenever it detects an insecure
 context. Running the server with HTTPS resolves webcam and sensor issues and
 allows all participants to meet in the same world.
 
-> The certificate scripts use OpenSSL. Install it beforehand if it is not already available.
+ > The Linux certificate script requires OpenSSL. The PowerShell variant uses Windows’ built-in cryptography and needs no additional tools.
 
 ### Controls
 - Choose FPV, Spectator or Lakitu from the start menu

--- a/create_mingle_cert.ps1
+++ b/create_mingle_cert.ps1
@@ -1,5 +1,43 @@
-# PowerShell script to generate a self-signed certificate for the Mingle prototype.
-# Requires OpenSSL to be installed and available in the PATH.
-New-Item -ItemType Directory -Path certs -Force | Out-Null
-openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout certs/mingle.key -out certs/mingle.cert -subj "/CN=localhost"
-Write-Host "Certificate and key generated in certs\"
+<#
+File: create_mingle_cert.ps1
+Mini README:
+- Purpose: generate a self-signed certificate and key for the Mingle server on Windows.
+- Structure:
+  1. Prepare output directory.
+  2. Create self-signed certificate using Windows cryptography.
+  3. Export certificate and private key in PEM format.
+  4. Remove the temporary certificate from the user store and report success.
+- Notes: no external dependencies such as OpenSSL are required.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$certDir = Join-Path $PSScriptRoot 'certs'
+New-Item -ItemType Directory -Path $certDir -Force | Out-Null
+
+try {
+    # Generate a self-signed certificate valid for one year.
+    $cert = New-SelfSignedCertificate -DnsName 'localhost' `
+        -CertStoreLocation Cert:\CurrentUser\My `
+        -NotAfter (Get-Date).AddDays(365)
+
+    # Export the public certificate in PEM format.
+    Export-Certificate -Cert $cert -FilePath (Join-Path $certDir 'mingle.cert') | Out-Null
+
+    # Export the private key in PKCS#8 PEM format.
+    $rsa = $cert.GetRSAPrivateKey()
+    $keyBytes = $rsa.ExportPkcs8PrivateKey()
+    $keyPem = "-----BEGIN PRIVATE KEY-----`n" +
+        [System.Convert]::ToBase64String($keyBytes, [System.Base64FormattingOptions]::InsertLineBreaks) +
+        "`n-----END PRIVATE KEY-----"
+    Set-Content -Path (Join-Path $certDir 'mingle.key') -Value $keyPem
+
+    # Clean up the certificate store to avoid clutter.
+    Remove-Item -Path "Cert:\CurrentUser\My\$($cert.Thumbprint)" -Force
+
+    Write-Host "Certificate and key generated in $certDir"
+} catch {
+    Write-Error "Failed to generate certificate: $_"
+    exit 1
+}


### PR DESCRIPTION
## Summary
- replace PowerShell certificate script with OpenSSL-free implementation
- clarify README that only Linux script needs OpenSSL

## Testing
- `npm test` *(fails: Missing script "test")*
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_689749f6008c8328a1751d42cedbb115