### PR TITLE
feat: guard Windows PowerShell

### DIFF
--- a/create_mingle_cert.ps1
+++ b/create_mingle_cert.ps1
@@ -3,15 +3,24 @@ File: create_mingle_cert.ps1
 Mini README:
 - Purpose: generate a self-signed certificate and key for the Mingle server on Windows.
 - Structure:
-  1. Prepare output directory.
-  2. Create self-signed certificate using Windows cryptography.
-  3. Export certificate and private key in PEM format.
-  4. Remove the temporary certificate from the user store and report success.
+  1. Verify the PowerShell edition and version.
+  2. Prepare output directory.
+  3. Create self-signed certificate using Windows cryptography.
+  4. Export certificate and private key in PEM format.
+  5. Remove the temporary certificate from the user store and report success.
 - Notes: no external dependencies such as OpenSSL are required.
 #>
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+# Detect PowerShell edition and version to ensure compatibility.
+$edition = $PSVersionTable.PSEdition
+$version = $PSVersionTable.PSVersion
+if ($edition -eq 'Desktop' -and $version.Major -le 5) {
+    Write-Error "Windows PowerShell $version is unsupported. Please install PowerShell 7+ to run this script."
+    exit 1
+}
 
 $certDir = Join-Path $PSScriptRoot 'certs'
 New-Item -ItemType Directory -Path $certDir -Force | Out-Null


### PR DESCRIPTION
## Summary
- ensure certificate script checks PS edition and version
- warn and exit when running under Windows PowerShell 5.1 or lower

## Testing
- `pwsh -NoLogo -File create_mingle_cert.ps1` *(fails: The term 'New-SelfSignedCertificate' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6897c642c8248328beb0f9082a3a1115