### PR TITLE
Enable WebRTC webcam sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ first-person avatar whose face displays a live webcam feed.
 - WASD + mouse look movement with the camera pinned to the avatar centre
 - Toggleable spectate mode to view the scene from a fixed overhead camera
 - Webcam feed mapped onto the front face of the local avatar
+- Peer-to-peer webcam sharing so remote avatars display live video via WebRTC
 - Basic multi-user position synchronisation via Socket.io
 - Configurable port via `PORT` environment variable
 - Configurable host via `LISTEN_HOST` environment variable

--- a/public/index.html
+++ b/public/index.html
@@ -8,8 +8,7 @@
     2. Entry mode menu and on-screen usage instructions
     3. Camera control sidebar with real-time status
     4. A-Frame scene setup with assets, cameras, avatar and spectate marker
-       (webcam only on front face; remote avatars mirror this layout with a
-       placeholder colour until video streaming is available)
+       (local and remote avatars display webcam feeds via WebRTC)
     5. Client scripts for movement and navbar functionality
   - Notes: A-Frame's default WASD controls are disabled on all cameras so that
     movement is handled exclusively by custom code in mingle_client.js.
@@ -185,9 +184,8 @@
            feed and a rear backing plane so the video only appears on the face
            pointing in the camera direction. Remote participants are rendered
            on every client by duplicating this front/back layout; their video
-           plane currently uses a placeholder colour until streaming is wired
-           up. The camera itself sits at the origin, directly behind the avatar's
-           front face. -->
+           plane streams each participant's webcam via WebRTC. The camera itself
+           sits at the origin, directly behind the avatar's front face. -->
       <a-camera id="playerCamera" position="0 0 0" look-controls="pointerLockEnabled: true" wasd-controls="enabled: false"></a-camera>
       <!-- Position the avatar directly in front of the player camera. The video
            plane is rotated to face the same direction as the player so all


### PR DESCRIPTION
## Summary
- Relay WebRTC signalling messages on the server so clients can establish peer connections
- Stream webcams via WebRTC and attach remote video textures to avatar planes
- Document peer webcam streaming in README and index page notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0ecf2e2b48328b6c9fcee01e085bd