### PR TITLE
docs: add page overview comments to account screens

### DIFF
--- a/public/learning_zone.html
+++ b/public/learning_zone.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
+<!--
+  learning_zone.html
+  Mini README:
+  - Purpose: provides tutorials and guides for users exploring the platform.
+  - Structure:
+    1. Fixed navigation bar with profile menu
+    2. Main content area presenting learning resources
+  - Notes: Uses shared navbar styling and dropdown behavior via mingle_navbar.js.
+-->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/public/manage_profiles.html
+++ b/public/manage_profiles.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
+<!--
+  manage_profiles.html
+  Mini README:
+  - Purpose: allows users to update profile information and navigate to other sections.
+  - Structure:
+    1. Fixed navigation bar with profile menu
+    2. Main content area for profile management instructions
+  - Notes: Shares styling and dropdown logic with other account screens via mingle_navbar.js.
+-->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/public/manage_users.html
+++ b/public/manage_users.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
+<!--
+  manage_users.html
+  Mini README:
+  - Purpose: allows administrators to control user access and permissions.
+  - Structure:
+    1. Fixed navigation bar with profile menu
+    2. Main content area for user management actions
+  - Notes: Shares consistent styling and dropdown navigation via mingle_navbar.js.
+-->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/public/my_details.html
+++ b/public/my_details.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
+<!--
+  my_details.html
+  Mini README:
+  - Purpose: displays and lets users edit their personal account information.
+  - Structure:
+    1. Fixed navigation bar with profile menu
+    2. Main content area showing editable personal details
+  - Notes: Shares common styling and dropdown navigation through mingle_navbar.js.
+-->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/public/subscription_details.html
+++ b/public/subscription_details.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
+<!--
+  subscription_details.html
+  Mini README:
+  - Purpose: lets users review their subscription and billing information.
+  - Structure:
+    1. Fixed navigation bar with profile menu
+    2. Main content area summarizing subscription details
+  - Notes: Reuses global navbar styling and dropdown script for consistent navigation.
+-->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />


### PR DESCRIPTION
## Summary
- document account-related pages with inline mini README blocks following index.html format

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a220f2a3688328be39f0c09bd66e59