### PR TITLE
Add Helmet middleware for security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ first-person avatar whose face displays a live webcam feed.
 - Randomised spawn positions so newcomers are immediately visible
 - On-screen warning when not using HTTPS so webcams and sensors work over LAN
 - Live participant count displayed for quick diagnostics
+- Default security headers applied via [Helmet](https://helmetjs.github.io/)
 
 ## Quick Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "express": "^4.21.2",
+        "helmet": "^8.1.0",
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
@@ -603,6 +604,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
+    "helmet": "^8.1.0",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {

--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -5,12 +5,13 @@
  * - Structure:
  *   1. Configuration flags (port, host, HTTPS, debug)
  *   2. Server creation (HTTP/HTTPS)
- *   3. Static routes and config endpoint
+ *   3. Security middleware (Helmet) followed by static routes and config endpoint
  *   4. Socket.io events for position, participant count and WebRTC signalling
  *   5. Startup logging with LAN-friendly addresses and HTTP/HTTPS guidance
- * - Notes: set LISTEN_HOST=0.0.0.0 to allow LAN clients. Use --debug for verbose logs.
+ * - Notes: set LISTEN_HOST=0.0.0.0 to allow LAN clients. Use --debug for verbose logs. Default security headers applied via Helmet.
  */
 import express from 'express';
+import helmet from 'helmet';
 import fs from 'fs';
 import http from 'http';
 import https from 'https';
@@ -35,6 +36,8 @@ const CERT_PATH: string = process.env.SSL_CERT || path.join(__dirname, '../certs
 const DEBUG: boolean = process.argv.includes('--debug');
 
 const app = express();
+// Apply security headers early to protect all routes
+app.use(helmet());
 
 // Create either an HTTP or HTTPS server depending on configuration. When HTTPS
 // is enabled the provided certificate is loaded. Fail early if certificates are


### PR DESCRIPTION
## Summary
- install Helmet for default security headers
- apply Helmet middleware before defining routes
- document security headers in README and server mini README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a222cc6220832886194130cea31027