### PR TITLE
feat: add mobile movement buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ first-person avatar whose face displays a live webcam feed.
 ## Features
 - Start menu offering FPV, Spectator and Lakitu viewing modes
 - WASD + mouse look movement with the camera pinned to the avatar centre
+- On-screen arrow buttons for movement on touch devices
 - Toggleable spectate mode to view the scene from a fixed overhead camera
 - Webcam feed mapped onto the front face of the local avatar
 - Peer-to-peer webcam sharing so remote avatars display live video via WebRTC
@@ -73,7 +74,7 @@ allows all participants to meet in the same world.
 
 ### Controls
 - Choose FPV, Spectator or Lakitu from the start menu
-- `WASD` to move, mouse to look around
+- `WASD` or tap the on-screen arrows to move; mouse or touch to look around
 - Press `P` to toggle spectate mode (not available in Lakitu mode)
 
 ### Troubleshooting

--- a/public/index.html
+++ b/public/index.html
@@ -6,10 +6,11 @@
   - Structure:
     1. Page styling and navigation bar
     2. Entry mode menu and on-screen usage instructions
-    3. Camera control sidebar with real-time status
-    4. A-Frame scene setup with assets, cameras, avatar and spectate marker
+    3. Mobile movement buttons
+    4. Camera control sidebar with real-time status
+    5. A-Frame scene setup with assets, cameras, avatar and spectate marker
        (local and remote avatars display webcam feeds via WebRTC)
-    5. Client scripts for movement and navbar functionality
+    6. Client scripts for movement and navbar functionality
   - Notes: A-Frame's default WASD controls are disabled on all cameras so that
     movement is handled exclusively by custom code in mingle_client.js.
 -->
@@ -109,6 +110,33 @@
       padding: 10px 15px;
       cursor: pointer;
     }
+    /* On-screen movement buttons for touch devices; hidden on wide screens */
+    #movementControls {
+      position: fixed;
+      bottom: 20px;
+      left: 20px;
+      z-index: 150;
+      display: none;
+    }
+    #movementControls button {
+      width: 50px;
+      height: 50px;
+      opacity: 0.8;
+      background: rgba(0,0,0,0.6);
+      color: #fff;
+      border: 1px solid #555;
+      border-radius: 4px;
+      touch-action: none;
+    }
+    @media (max-width: 800px) {
+      #movementControls {
+        display: grid;
+        grid-template-columns: repeat(3, 50px);
+        grid-template-rows: repeat(3, 50px);
+        gap: 5px;
+      }
+      #movementControls .spacer { visibility: hidden; }
+    }
   </style>
   <!--
     Load A-Frame and supporting libraries *before* the scene so that all
@@ -142,8 +170,20 @@
     <button data-mode="lakitu">Lakitu mode</button>
   </div>
   <div id="instructions">
-    <p>Choose a mode, then use WASD to move and mouse to look. Click to lock pointer.</p>
+    <p>Choose a mode, then use WASD or tap the on-screen arrows to move and mouse or touch to look. Click to lock pointer.</p>
     <p>Use the profile button in the top-right to access account options.</p>
+  </div>
+
+  <div id="movementControls">
+    <div class="spacer"></div>
+    <button id="moveForward" aria-label="Move forward">▲</button>
+    <div class="spacer"></div>
+    <button id="moveLeft" aria-label="Move left">◀</button>
+    <div class="spacer"></div>
+    <button id="moveRight" aria-label="Move right">▶</button>
+    <div class="spacer"></div>
+    <button id="moveBackward" aria-label="Move backward">▼</button>
+    <div class="spacer"></div>
   </div>
 
   <aside id="sidebar">

--- a/public/js/movement.js
+++ b/public/js/movement.js
@@ -5,8 +5,9 @@
  *   with the server.
  * - Structure:
  *   1. Key state tracking
- *   2. Frame-based movement loop
- *   3. Periodic position emission to the server
+ *   2. Touch movement button handlers
+ *   3. Frame-based movement loop
+ *   4. Periodic position emission to the server
  * - Notes: Depends on ui_controls.js for current mode and status updates.
  */
 import { MODE_LAKITU, MODE_SPECTATOR, getCurrentMode, updateStatus } from './ui_controls.js';
@@ -29,6 +30,35 @@ export function initMovement({ player, playerCamera, spectateCam, spectateMarker
       keys[k] = false;
     }
   });
+
+  // Bind on-screen movement buttons for touch interfaces
+  const btnForward = document.getElementById('moveForward');
+  const btnBackward = document.getElementById('moveBackward');
+  const btnLeft = document.getElementById('moveLeft');
+  const btnRight = document.getElementById('moveRight');
+
+  const bindButton = (btn, key) => {
+    if (!btn) return;
+    const activate = e => {
+      e.preventDefault();
+      keys[key] = true;
+      debugLog(`Button ${key} pressed`);
+    };
+    const deactivate = e => {
+      e.preventDefault();
+      keys[key] = false;
+      debugLog(`Button ${key} released`);
+    };
+    btn.addEventListener('pointerdown', activate);
+    btn.addEventListener('pointerup', deactivate);
+    btn.addEventListener('pointerleave', deactivate);
+    btn.addEventListener('pointercancel', deactivate);
+  };
+
+  bindButton(btnForward, 'w');
+  bindButton(btnBackward, 's');
+  bindButton(btnLeft, 'a');
+  bindButton(btnRight, 'd');
 
   const MOVE_SPEED = 2; // metres per second
   let lastMove = performance.now();


### PR DESCRIPTION
## Summary
- add responsive arrow key overlay for touch-based movement
- wire mobile buttons into existing movement logic
- document mobile controls in README and on-screen instructions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2241643c48328b56e27dd160cbc36