### PR TITLE
Fix unresponsive mode selection buttons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -165,9 +165,12 @@
   <!-- Initial mode selection menu displayed before entering the world -->
   <div id="modeMenu">
     <p>Select how to enter the world:</p>
-    <button data-mode="fpv">FPV mode</button>
-    <button data-mode="spectator">Spectator mode</button>
-    <button data-mode="lakitu">Lakitu mode</button>
+    <!-- Explicit button types prevent accidental form submission in
+         embedded browsers where default type="submit" could cause
+         page refreshes. -->
+    <button type="button" data-mode="fpv">FPV mode</button>
+    <button type="button" data-mode="spectator">Spectator mode</button>
+    <button type="button" data-mode="lakitu">Lakitu mode</button>
   </div>
   <div id="instructions">
     <p>Choose a mode, then use WASD or tap the on-screen arrows to move and mouse or touch to look. Click to lock pointer.</p>

--- a/public/js/ui_controls.js
+++ b/public/js/ui_controls.js
@@ -57,15 +57,16 @@ export function initUIControls(opts) {
   activeCamera = playerCamera;
   spectateCam.setAttribute('wasd-controls', 'enabled', false);
 
-  // Delegate clicks on the mode menu so that all current and future buttons
-  // trigger mode selection without relying on NodeList.forEach support.
+  // Wire up explicit handlers for each mode selection button. Delegated
+  // listeners on the container failed in some embedded browsers, leaving the
+  // menu unresponsive. Direct listeners ensure clicks always register.
   if (modeMenu) {
-    modeMenu.addEventListener('click', event => {
-      const button = event.target.closest('button');
-      if (button && button.dataset.mode) {
-        debugLog('Mode button clicked', button.dataset.mode);
-        selectMode(button.dataset.mode);
-      }
+    const buttons = modeMenu.querySelectorAll('button[data-mode]');
+    buttons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        debugLog('Mode button clicked', btn.dataset.mode);
+        selectMode(btn.dataset.mode);
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure 'how to enter the world' buttons work by adding explicit button types and direct click handlers

## Testing
- `npm run build`
- (attempted) `node test_mode_menu.js` *(missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a2329329708328a72747a1efe17473