### PR TITLE
Fix missing 3D world by relaxing CSP and hiding video elements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -209,8 +209,10 @@
         Include the video element used for the local webcam feed. The `muted`
         attribute ensures browsers allow autoplay which lets A-Frame finish
         loading instead of leaving the user on the default blue loading screen.
+        The element is hidden so if A-Frame fails to initialise the raw
+        webcam feed does not appear on screen.
       -->
-      <video id="localVideo" autoplay playsinline muted></video>
+      <video id="localVideo" autoplay playsinline muted style="display:none"></video>
     </a-assets>
 
     <!-- Simple floor and lighting -->

--- a/public/js/webrtc.js
+++ b/public/js/webrtc.js
@@ -21,7 +21,10 @@ export function initWebRTC({ socket, sceneEl }) {
       const videoEl = document.getElementById('localVideo');
       videoEl.muted = true;
       videoEl.srcObject = stream;
-      videoEl.onloadeddata = () => debugLog('Webcam video element loaded');
+      // Hide the element to avoid displaying the raw feed if the A-Frame scene
+      // fails to initialise and <a-assets> remains visible.
+      videoEl.style.display = 'none';
+     videoEl.onloadeddata = () => debugLog('Webcam video element loaded');
       return videoEl.play()
         .then(() => { debugLog('Webcam stream started'); return stream; })
         .catch(err => { debugError('Webcam playback failed', err); return stream; });
@@ -110,6 +113,9 @@ export function initWebRTC({ socket, sceneEl }) {
       videoEl.autoplay = true;
       videoEl.playsInline = true;
       videoEl.muted = true;
+      // Ensure remote video elements never leak onto the page should A-Frame
+      // fail to hide <a-assets> when blocked by CSP or similar issues.
+      videoEl.style.display = 'none';
       assetsEl.appendChild(videoEl);
 
       const front = document.createElement('a-plane');

--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -63,10 +63,18 @@ const app = express();
 // STUN is permitted for WebRTC connectivity.
 const CSP_DIRECTIVES = {
   defaultSrc: ["'self'"],
-  scriptSrc: ["'self'", 'https://aframe.io', 'https://cdn.jsdelivr.net'],
+  // Allow loading of A-Frame and Socket.IO from trusted CDNs and permit
+  // creation of blob-based workers used by Three.js/A-Frame under the hood.
+  scriptSrc: ["'self'", 'https://aframe.io', 'https://cdn.jsdelivr.net', 'blob:'],
   styleSrc: ["'self'", "'unsafe-inline'"],
   imgSrc: ["'self'", 'data:', 'https://via.placeholder.com'],
-  connectSrc: ["'self'", 'stun:'],
+  // Permit WebRTC STUN traffic and any auxiliary requests A-Frame performs
+  // (such as fetching additional script helpers) along with blob URLs for
+  // webcam streams.
+  connectSrc: ["'self'", 'stun:', 'https://aframe.io', 'https://cdn.jsdelivr.net', 'blob:'],
+  // Explicitly allow blob URLs so MediaStreams can be played without CSP
+  // violations when rendered to <video> elements.
+  mediaSrc: ["'self'", 'blob:'],
 };
 app.use(
   helmet({


### PR DESCRIPTION
## Summary
- relax Content Security Policy to permit A-Frame helpers and blob URLs used by webcam streams
- hide local and remote webcam `<video>` elements so raw feeds never overlay the scene

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a325ec3564832883568545b8d1ad89