### PR TITLE
Allow blob workers for A-Frame

### DIFF
--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -75,6 +75,10 @@ const CSP_DIRECTIVES = {
   // Explicitly allow blob URLs so MediaStreams can be played without CSP
   // violations when rendered to <video> elements.
   mediaSrc: ["'self'", 'blob:'],
+  // Permit creation of Web Workers from blob URLs; required by A-Frame/Three.js
+  // for features like compressed texture loading and is essential for the 3D
+  // scene to initialise correctly.
+  workerSrc: ["'self'", 'blob:'],
 };
 app.use(
   helmet({


### PR DESCRIPTION
## Summary
- permit `blob:` Web Workers in Content Security Policy so A-Frame can spawn workers

## Testing
- `npm run build`
- `curl -sI http://localhost:3000/ | grep -i worker-src`


------
https://chatgpt.com/codex/tasks/task_e_68a32918033c8328a273ec5e61525a58