### PR TITLE
Gracefully handle WebRTC initialization errors

### DIFF
--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -86,6 +86,22 @@ initUIControls({
 });
 
 if (socket) {
-  initWebRTC({ socket, sceneEl });
-  initMovement({ player, playerCamera, spectateCam, spectateMarker, avatar, socket, playerColor });
+  // Attempt to start WebRTC; on failure fall back to movement-only mode.
+  try {
+    initWebRTC({ socket, sceneEl });
+  } catch (err) {
+    document.getElementById('instructions').innerHTML +=
+      '<p>Webcam unavailable; running without video.</p>';
+    debugError('WebRTC initialisation failed', err);
+  }
+  // Always initialise movement so the 3D scene remains interactive.
+  initMovement({
+    player,
+    playerCamera,
+    spectateCam,
+    spectateMarker,
+    avatar,
+    socket,
+    playerColor
+  });
 }


### PR DESCRIPTION
## Summary
- Wrap WebRTC startup in try/catch so failures don't block scene rendering
- Show concise on-screen message when webcam unavailable and log details with `debugError`
- Always initialize movement to keep 3D scene interactive even without video

## Testing
- `npm test` *(fails: Missing script "test"; no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a4162ef2e08328b8e68855b4318764