### PR TITLE
Enable spatial audio playback for remote avatars

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -207,6 +207,7 @@
 
   <!-- Client logic is loaded last once the DOM and libraries are ready -->
   <script src="js/mingle_client.js"></script>
+  <script src="js/webrtc.js"></script>
   <script src="js/mingle_navbar.js"></script>
 </body>
 </html>

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -213,6 +213,12 @@ async function createPeerConnection(id) {
       videoEl.srcObject = event.streams[0];
       videoEl.play().catch(err => debugError('Remote video playback failed', err));
     }
+    // Route accompanying audio through positional sound helpers.
+    if (typeof attachRemoteAudio === 'function') {
+      attachRemoteAudio(event.streams[0], id);
+    } else {
+      debugError('attachRemoteAudio not available for remote stream', id);
+    }
   };
 
   pc.onicecandidate = (event) => {
@@ -475,6 +481,7 @@ socket.on('position', async data => {
     // displays the participant's video stream and a white backing plane so the
     // texture only appears on the front.
     const avatarEntity = document.createElement('a-entity');
+    avatarEntity.id = `avatar-${data.id}`; // allow audio entities to attach for spatial sound
 
     const videoEl = document.createElement('video');
     videoEl.id = `video-${data.id}`;

--- a/public/js/webrtc.js
+++ b/public/js/webrtc.js
@@ -1,0 +1,67 @@
+/**
+ * webrtc.js
+ * Mini README:
+ * - Purpose: client-side helpers for handling remote WebRTC audio with
+ *   positional playback for avatars.
+ * - Structure:
+ *   1. Utility helpers to locate or create audio elements and A-Frame sound
+ *      entities for each remote participant.
+ *   2. attachRemoteAudio(stream, id) entry point used by mingle_client.js to
+ *      route incoming media streams into spatial audio sources.
+ * - Audio entity: an <a-entity id="audio-entity-{id}"> with the `sound`
+ *   component is appended beneath the matching remote avatar
+ *   (id="avatar-{id}") so that audio follows that avatar in 3D space.
+ */
+
+/** Retrieve or create the DOM nodes needed for positional audio. */
+function ensureAudioTargets(id) {
+  const sceneEl = document.querySelector('a-scene');
+  const assetsEl = sceneEl ? sceneEl.querySelector('a-assets') : null;
+  if (!assetsEl) {
+    debugError('A-Frame assets container not found; audio stream ignored');
+    return {};
+  }
+
+  // Create or reuse an <audio> element for the remote stream.
+  let audioEl = document.getElementById(`audio-${id}`);
+  if (!audioEl) {
+    audioEl = document.createElement('audio');
+    audioEl.id = `audio-${id}`;
+    audioEl.autoplay = true;
+    audioEl.crossOrigin = 'anonymous';
+    assetsEl.appendChild(audioEl);
+  }
+
+  // Create or reuse the positional sound entity under the remote avatar.
+  let soundEntity = document.getElementById(`audio-entity-${id}`);
+  if (!soundEntity) {
+    const avatar = document.getElementById(`avatar-${id}`);
+    if (avatar) {
+      soundEntity = document.createElement('a-entity');
+      soundEntity.id = `audio-entity-${id}`;
+      soundEntity.setAttribute('sound', `src: #audio-${id}; autoplay: true; positional: true`);
+      avatar.appendChild(soundEntity);
+    } else {
+      debugError(`Remote avatar avatar-${id} not found; spatial audio disabled`);
+    }
+  }
+
+  return { audioEl, soundEntity };
+}
+
+/** Attach a remote MediaStream to audio playback with debug logging. */
+function attachRemoteAudio(stream, id) {
+  const { audioEl } = ensureAudioTargets(id);
+  if (!audioEl) {
+    debugError('Failed to create audio element for remote stream', id);
+    return;
+  }
+
+  audioEl.srcObject = stream;
+  audioEl.play()
+    .then(() => debugLog('Remote audio playing for', id))
+    .catch(err => debugError('Remote audio playback failed', err));
+}
+
+// Expose helper to global scope so mingle_client.js can invoke it.
+window.attachRemoteAudio = attachRemoteAudio;


### PR DESCRIPTION
## Summary
- add helper to create audio elements and positional A-Frame sound entities for remote streams
- tag remote avatar entities with IDs so audio sources can attach
- wire up audio handling in WebRTC ontrack and include new helper script

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a476d8a4748328bd42d95566705a49