### PR TITLE
feat: add microphone mute control

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -144,10 +144,13 @@
   <div id="instructions">
     <p>Choose a mode, then use WASD to move and mouse to look. Click to lock pointer.</p>
     <p>Use the profile button in the top-right to access account options.</p>
+    <p>Allow microphone access when prompted so others can hear you. Use the mute control in the sidebar to silence yourself.</p>
   </div>
 
   <aside id="sidebar">
     <label><input type="checkbox" id="spectateToggle"> Spectate mode</label><br />
+    <label><input type="checkbox" id="muteToggle"> Mute microphone</label><br />
+    <div id="micStatus">Mic: live</div>
     <div>
       <p>Viewpoint:</p>
       <label><input type="radio" name="viewpoint" value="high" checked> High corner</label><br />
@@ -208,6 +211,7 @@
   <!-- Client logic is loaded last once the DOM and libraries are ready -->
   <script src="js/mingle_client.js"></script>
   <script src="js/webrtc.js"></script>
+  <script src="js/ui_controls.js"></script>
   <script src="js/mingle_navbar.js"></script>
 </body>
 </html>

--- a/public/js/ui_controls.js
+++ b/public/js/ui_controls.js
@@ -1,0 +1,56 @@
+/**
+ * ui_controls.js
+ * Mini README:
+ * - Purpose: handle interactive sidebar controls such as the microphone mute toggle.
+ * - Structure:
+ *   1. Cache DOM elements and initialise status text when the document loads.
+ *   2. Event listener that toggles the local audio track and updates on-screen state.
+ * - Notes: Requires mingle_client.js to initialise the #localVideo stream beforehand.
+ */
+
+// Wait for the DOM to be ready before querying elements.
+document.addEventListener('DOMContentLoaded', () => {
+  const muteToggle = document.getElementById('muteToggle');
+  const micStatus = document.getElementById('micStatus');
+
+  // Ensure required elements exist to avoid runtime errors.
+  if (!muteToggle || !micStatus) {
+    if (typeof debugError === 'function') {
+      debugError('Microphone controls not found in DOM');
+    } else {
+      console.error('Microphone controls not found in DOM');
+    }
+    return;
+  }
+
+  // Display initial microphone state for clarity.
+  micStatus.textContent = 'Mic: live';
+
+  // Toggle the local audio track whenever the checkbox changes.
+  muteToggle.addEventListener('change', () => {
+    const videoEl = document.getElementById('localVideo');
+    const stream = videoEl ? videoEl.srcObject : null;
+    const tracks = stream ? stream.getAudioTracks() : [];
+
+    if (tracks.length === 0) {
+      if (typeof debugError === 'function') {
+        debugError('No local audio track available to toggle');
+      } else {
+        console.error('No local audio track available to toggle');
+      }
+      return;
+    }
+
+    // Enable or disable all audio tracks based on the checkbox state.
+    const muted = muteToggle.checked;
+    tracks.forEach(track => {
+      track.enabled = !muted;
+    });
+
+    micStatus.textContent = muted ? 'Mic: muted' : 'Mic: live';
+
+    if (typeof debugLog === 'function') {
+      debugLog(`Microphone ${muted ? 'muted' : 'unmuted'}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add on-screen guidance for granting microphone access
- introduce sidebar mute toggle and status display
- wire up mute toggle to local audio track in new ui_controls module

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a47813806083288e58d6166c2750e0