### PR TITLE
docs: add microphone audio setup and debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,48 @@ If `create_mingle_cert.ps1` reports that `GetRSAPrivateKey` is missing, the
 script is running under Windows PowerShell 5.1. Launch it from a PowerShell 7
 (`pwsh`) session or use the `create_mingle_cert.sh` script under WSL.
 
+## Microphone Audio
+
+Mingle relies on the browser's WebRTC stack for voice chat. Browsers require a
+secure context and explicit permission before exposing the microphone.
+
+### Setup (Linux / Raspberry Pi)
+```bash
+# List devices and optionally record a 3s sample
+./debug_mingle_audio.sh
+
+# Example: select a specific ALSA device and enable verbose logging
+MINGLE_AUDIO_DEVICE=hw:1,0 MINGLE_AUDIO_DEBUG=true ./debug_mingle_audio.sh
+```
+Ensure the `arecord` or `pactl` utility is installed. Recording a sample
+requires `ffmpeg`. Run the server with `USE_HTTPS=true` so the browser can grant
+microphone access.
+
+### Setup (Windows PowerShell)
+```powershell
+# List devices and optionally record a 3s sample
+./debug_mingle_audio.ps1
+
+# Example: select a device and enable verbose logging
+$env:MINGLE_AUDIO_DEVICE="Your Microphone"; $env:MINGLE_AUDIO_DEBUG="true"; ./debug_mingle_audio.ps1
+```
+`Get-PnpDevice` may require administrative privileges. Recording a sample uses
+`ffmpeg` if present in the `PATH`. Start the server with `$env:USE_HTTPS="true"`
+to allow the browser to request microphone permissions.
+
+### Environment Variables
+- `MINGLE_AUDIO_DEVICE` – optional device name or ID for the debug scripts.
+- `MINGLE_AUDIO_DEBUG` – set to `true` to record a short sample for diagnostics.
+
+### Troubleshooting
+- Always serve the site over HTTPS; browsers block microphone access on HTTP.
+- Confirm the browser prompts for microphone access and that permission is
+  granted.
+- Run the server with `--debug` or set `MINGLE_AUDIO_DEBUG=true` for additional
+  logging.
+- Use the provided debug scripts to verify that the OS detects the microphone
+  and to capture a short test recording.
+
 ## Docker Deployment
 
 ### Linux / Raspberry Pi

--- a/debug_mingle_audio.ps1
+++ b/debug_mingle_audio.ps1
@@ -1,0 +1,37 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  debug_mingle_audio.ps1
+  Mini README:
+  - Purpose: list available microphone devices and optionally record a short sample to aid debugging for Mingle.
+  - Structure:
+    1. List devices using Get-PnpDevice.
+    2. Optionally record a 3s sample when $env:MINGLE_AUDIO_DEBUG is true.
+  - Notes: requires ffmpeg in PATH for recording. Set $env:MINGLE_AUDIO_DEVICE to specify the capture device.
+#>
+Set-StrictMode -Version Latest
+
+$device = $env:MINGLE_AUDIO_DEVICE
+$debug = $env:MINGLE_AUDIO_DEBUG -eq 'true'
+
+Write-Host 'Available capture devices:'
+try {
+    Get-PnpDevice -Class AudioEndpoint | Where-Object { $_.FriendlyName -like '*microphone*' } | Format-Table -AutoSize
+} catch {
+    Write-Warning 'Get-PnpDevice not available. Run with administrative privileges.'
+}
+
+if ($debug) {
+    Write-Host 'MINGLE_AUDIO_DEBUG enabled'
+    if (Get-Command ffmpeg -ErrorAction SilentlyContinue) {
+        $out = 'mic_debug.wav'
+        Write-Host "Recording 3s sample to $out"
+        if ($device) {
+            ffmpeg -y -f dshow -i "audio=$device" -t 3 $out
+        } else {
+            ffmpeg -y -f dshow -i audio="default" -t 3 $out
+        }
+    } else {
+        Write-Warning 'ffmpeg not installed; skipping sample recording'
+    }
+}

--- a/debug_mingle_audio.sh
+++ b/debug_mingle_audio.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# debug_mingle_audio.sh
+# Mini README:
+# - Purpose: list available microphone devices and optionally record a short sample to aid debugging for Mingle.
+# - Structure:
+#   1. List devices using arecord or pactl.
+#   2. Optionally record a 3s sample when MINGLE_AUDIO_DEBUG=true.
+# - Notes: requires alsa-utils or pulseaudio-utils. Set MINGLE_AUDIO_DEVICE to choose a device. ffmpeg is used for recording if available.
+set -euo pipefail
+
+DEVICE="${MINGLE_AUDIO_DEVICE:-}"
+DEBUG="${MINGLE_AUDIO_DEBUG:-false}"
+
+echo "Available capture devices:"
+if command -v arecord >/dev/null 2>&1; then
+  arecord -l || true
+elif command -v pactl >/dev/null 2>&1; then
+  pactl list short sources || true
+else
+  echo "No arecord or pactl found. Install alsa-utils or pulseaudio-utils." >&2
+fi
+
+if [ "$DEBUG" = "true" ]; then
+  echo "MINGLE_AUDIO_DEBUG enabled"
+  if command -v ffmpeg >/dev/null 2>&1; then
+    OUTPUT_FILE="mic_debug.wav"
+    echo "Recording 3s sample to $OUTPUT_FILE"
+    if [ -n "$DEVICE" ]; then
+      ffmpeg -y -f alsa -i "$DEVICE" -t 3 "$OUTPUT_FILE"
+    else
+      ffmpeg -y -f alsa -i default -t 3 "$OUTPUT_FILE"
+    fi
+  else
+    echo "ffmpeg not installed; skipping sample recording" >&2
+  fi
+fi


### PR DESCRIPTION
## Summary
- document microphone setup on Linux, Windows, and Raspberry Pi
- add audio debug scripts for listing devices and recording samples
- highlight HTTPS requirement and new MINGLE_AUDIO_* env vars

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a47b6ac9808328882b2bef5fa96bb4