### PR TITLE
Add mobile joystick controls with optional manual camera look

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ first-person avatar whose face displays a live webcam feed.
 - Randomised spawn positions so newcomers are immediately visible
 - On-screen warning when not using HTTPS so webcams and sensors work over LAN
 - Live participant count displayed for quick diagnostics
+- Touch-friendly thumbsticks for movement with optional manual pan/tilt control on mobile devices
 
 ## Quick Start
 

--- a/public/index.html
+++ b/public/index.html
@@ -91,6 +91,15 @@
       font-size: 12px;
       color: #333;
     }
+    /* Containers for on-screen joysticks on touch devices */
+    #moveJoystick, #lookJoystick {
+      position: fixed;
+      width: 120px;
+      height: 120px;
+      z-index: 180;
+    }
+    #moveJoystick { left: 0; bottom: 0; }
+    #lookJoystick { right: 0; bottom: 0; display: none; }
     /* Simple start menu allowing users to choose their entry mode */
     #modeMenu {
       position: fixed;
@@ -117,6 +126,7 @@
   -->
   <script src="https://aframe.io/releases/1.7.1/aframe.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/socket.io-client@4.8.1/dist/socket.io.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/nipplejs@0.10.2/dist/nipplejs.min.js"></script>
   <script src="/config.js"></script>
 </head>
 <body>
@@ -145,11 +155,13 @@
     <p>Choose a mode, then use WASD to move and mouse to look. Click to lock pointer.</p>
     <p>Use the profile button in the top-right to access account options.</p>
     <p>Allow microphone access when prompted so others can hear you. Use the mute control in the sidebar to silence yourself.</p>
+    <p>On touch devices, a left thumbstick mirrors WASD movement. Enable Manual look to use a right thumbstick for camera pan/tilt.</p>
   </div>
 
   <aside id="sidebar">
     <label><input type="checkbox" id="spectateToggle"> Spectate mode</label><br />
     <label><input type="checkbox" id="muteToggle"> Mute microphone</label><br />
+    <label><input type="checkbox" id="lookToggle"> Manual look</label><br />
     <div id="micStatus">Mic: live</div>
     <div>
       <p>Viewpoint:</p>
@@ -159,6 +171,10 @@
     </div>
     <div id="status"></div>
   </aside>
+
+  <!-- Joystick containers positioned via CSS for touch navigation -->
+  <div id="moveJoystick"></div>
+  <div id="lookJoystick"></div>
 
   <!-- Main A-Frame scene. Removing 'embedded' allows full-screen rendering -->
   <!-- Disable the default loading screen so the environment appears even if the
@@ -210,6 +226,7 @@
 
   <!-- Client logic is loaded last once the DOM and libraries are ready -->
   <script src="js/mingle_client.js"></script>
+  <script src="js/mobile_controls.js"></script>
   <script src="js/webrtc.js"></script>
   <script src="js/ui_controls.js"></script>
   <script src="js/mingle_navbar.js"></script>

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -22,6 +22,9 @@ const avatar = document.getElementById('avatar');
 const avatarBack = document.getElementById('avatarBack');
 const player = document.getElementById('player');
 const playerCamera = document.getElementById('playerCamera');
+// Expose the primary camera globally so auxiliary modules (e.g. mobile
+// controls) can adjust its orientation directly when needed.
+window.playerCamera = playerCamera;
 const spectateCam = document.getElementById('spectateCam');
 const spectateMarker = document.getElementById('spectateMarker');
 const spectateToggle = document.getElementById('spectateToggle');
@@ -367,6 +370,9 @@ updateStatus();
 // manually. This avoids relying on A-Frame's wasd-controls which depend on the
 // currently active camera and caused erratic movement when spectating.
 const keys = { w: false, a: false, s: false, d: false };
+// Publish key state globally so other scripts (e.g. touch joystick handlers)
+// can mirror WASD input for mobile users.
+window.keys = keys;
 document.addEventListener('keydown', (e) => {
   const k = e.key.toLowerCase();
   if (k in keys) {

--- a/public/js/mobile_controls.js
+++ b/public/js/mobile_controls.js
@@ -1,0 +1,131 @@
+/**
+ * mobile_controls.js
+ * Mini README:
+ * - Purpose: provide touch-friendly joystick controls for movement and optional
+ *   manual camera panning on mobile devices.
+ * - Structure:
+ *   1. Initialise left thumbstick to mirror WASD movement keys.
+ *   2. Toggleable right thumbstick for manual camera pan/tilt when device
+ *      orientation is undesirable.
+ *   3. Animation loop applying look deltas to the player camera.
+ * - Notes: Requires mingle_client.js to define global `keys` and `playerCamera`.
+ */
+
+// Run after the DOM loads to ensure required elements exist.
+document.addEventListener('DOMContentLoaded', () => {
+  // Skip setup on non-touch devices where keyboard and mouse are available.
+  if (!('ontouchstart' in window)) {
+    return;
+  }
+
+  const moveZone = document.getElementById('moveJoystick');
+  const lookZone = document.getElementById('lookJoystick');
+  const lookToggle = document.getElementById('lookToggle');
+
+  if (!moveZone || !lookZone || !lookToggle) {
+    if (typeof debugError === 'function') {
+      debugError('Mobile controls: required DOM elements not found');
+    }
+    return;
+  }
+
+  // -------------------------------------------------------------------------
+  // Movement joystick mirrors WASD key state
+  // -------------------------------------------------------------------------
+  const moveStick = nipplejs.create({
+    zone: moveZone,
+    mode: 'static',
+    position: { left: '60px', bottom: '60px' },
+    color: 'white'
+  });
+
+  moveStick.on('move', (evt, data) => {
+    const dead = 0.3; // ignore tiny movements
+    const x = data.vector.x;
+    const y = data.vector.y;
+    keys.w = y < -dead;
+    keys.s = y > dead;
+    keys.a = x < -dead;
+    keys.d = x > dead;
+  });
+  moveStick.on('end', () => {
+    keys.w = keys.a = keys.s = keys.d = false;
+  });
+
+  if (typeof debugLog === 'function') {
+    debugLog('Movement joystick initialised');
+  }
+
+  // -------------------------------------------------------------------------
+  // Optional look joystick for manual pan/tilt
+  // -------------------------------------------------------------------------
+  let lookStick = null;
+  let manualLook = false;
+  const lookDelta = { x: 0, y: 0 };
+  const LOOK_SPEED = 1.5; // radians per second
+  let lastLook = performance.now();
+
+  function updateLook(t) {
+    const dt = (t - lastLook) / 1000;
+    lastLook = t;
+    if (manualLook) {
+      const rot = playerCamera.object3D.rotation;
+      rot.y -= lookDelta.x * LOOK_SPEED * dt;
+      rot.x -= lookDelta.y * LOOK_SPEED * dt;
+      // Clamp pitch to avoid flipping
+      rot.x = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, rot.x));
+    }
+    requestAnimationFrame(updateLook);
+  }
+  requestAnimationFrame(updateLook);
+
+  function enableLookStick() {
+    manualLook = true;
+    lookZone.style.display = 'block';
+    if (playerCamera.components['look-controls']) {
+      playerCamera.components['look-controls'].pause();
+    }
+    lookStick = nipplejs.create({
+      zone: lookZone,
+      mode: 'static',
+      position: { right: '60px', bottom: '60px' },
+      color: 'white'
+    });
+    lookStick.on('move', (evt, data) => {
+      lookDelta.x = data.vector.x;
+      lookDelta.y = data.vector.y;
+    });
+    lookStick.on('end', () => {
+      lookDelta.x = 0;
+      lookDelta.y = 0;
+    });
+    if (typeof debugLog === 'function') {
+      debugLog('Look joystick enabled');
+    }
+  }
+
+  function disableLookStick() {
+    manualLook = false;
+    lookZone.style.display = 'none';
+    lookDelta.x = lookDelta.y = 0;
+    if (lookStick) {
+      lookStick.destroy();
+      lookStick = null;
+    }
+    if (playerCamera.components['look-controls']) {
+      playerCamera.components['look-controls'].play();
+    }
+    if (typeof debugLog === 'function') {
+      debugLog('Look joystick disabled');
+    }
+  }
+
+  // Toggle based on checkbox state
+  lookToggle.addEventListener('change', () => {
+    if (lookToggle.checked) {
+      enableLookStick();
+    } else {
+      disableLookStick();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- expose camera and movement state for external modules
- integrate touch-friendly thumbsticks and manual look toggle for mobile
- document mobile joystick controls in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6e305a1d883288eb95d604a8210a7