### PR TITLE
Fix inverted Y axis for mobile look joystick

### DIFF
--- a/public/js/mobile_controls.js
+++ b/public/js/mobile_controls.js
@@ -93,7 +93,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     lookStick.on('move', (evt, data) => {
       lookDelta.x = data.vector.x;
-      lookDelta.y = data.vector.y;
+      // Invert Y axis so upward drag makes the camera look up
+      lookDelta.y = -data.vector.y;
     });
     lookStick.on('end', () => {
       lookDelta.x = 0;


### PR DESCRIPTION
## Summary
- Correct mobile look joystick so dragging up looks up, matching expected camera behavior

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6e6f72a3483288315085987778f80