### PR TITLE
feat: add world design options to admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ first-person avatar whose face displays a live webcam feed.
 - Live participant count displayed for quick diagnostics
 - Touch-friendly thumbsticks for movement with optional manual pan/tilt control on mobile devices
 - Secure admin page to configure world settings (requires `ADMIN_TOKEN`)
+- World design options (geometry and colour) configurable via the admin page
 
 ## Quick Start
 
@@ -56,7 +57,8 @@ npm start                            # run over HTTP and allow LAN clients
 
 ### World Administration
 
-Set an admin token to enable the configuration interface.
+Set an admin token to enable the configuration interface. Use the admin page to
+set the world name, maximum participants, welcome message, geometry and colour.
 
 #### Linux / Raspberry Pi
 ```bash

--- a/public/js/world_admin.js
+++ b/public/js/world_admin.js
@@ -6,8 +6,9 @@
  *   1. Helper debug logger
  *   2. Load existing config when requested
  *   3. Submit updates back to the server
+ *   4. Handle world design (geometry and colour) fields
  * - Notes: requires the admin token set on the server. Token is provided via the form.
- */
+*/
 function adminDebugLog(...args) {
   if (window.MINGLE_DEBUG) {
     console.log(...args);
@@ -18,6 +19,8 @@ const tokenInput = document.getElementById('token');
 const worldNameInput = document.getElementById('worldName');
 const maxParticipantsInput = document.getElementById('maxParticipants');
 const welcomeMessageInput = document.getElementById('welcomeMessage');
+const worldGeometrySelect = document.getElementById('worldGeometry');
+const worldColorInput = document.getElementById('worldColor');
 
 async function loadConfig() {
   const token = tokenInput.value.trim();
@@ -34,6 +37,8 @@ async function loadConfig() {
     worldNameInput.value = data.worldName;
     maxParticipantsInput.value = data.maxParticipants;
     welcomeMessageInput.value = data.welcomeMessage;
+    worldGeometrySelect.value = data.worldGeometry || 'plane';
+    worldColorInput.value = data.worldColor || '#00aaff';
     adminDebugLog('Loaded config', data);
   } catch (err) {
     console.error(err);
@@ -53,6 +58,8 @@ async function saveConfig() {
     worldName: worldNameInput.value.trim(),
     maxParticipants: Number(maxParticipantsInput.value),
     welcomeMessage: welcomeMessageInput.value.trim(),
+    worldGeometry: worldGeometrySelect.value,
+    worldColor: worldColorInput.value,
   };
   try {
     const res = await fetch('/world-config', {

--- a/public/world_admin.html
+++ b/public/world_admin.html
@@ -6,7 +6,8 @@
   - Structure:
     1. Navbar reused across Mingle pages
     2. Instructional form for admin token and world configuration values
-    3. Client-side script to load and save settings via the secure API
+    3. Fields for world design (geometry and colour)
+    4. Client-side script to load and save settings via the secure API
   - Notes: requires the server to be started with ADMIN_TOKEN for access.
 -->
 <html lang="en">
@@ -62,6 +63,14 @@
     <input type="number" id="maxParticipants" min="1" value="20" />
     <label for="welcomeMessage">Welcome Message</label>
     <textarea id="welcomeMessage" rows="3" placeholder="Welcome to Mingle"></textarea>
+    <label for="worldGeometry">World Geometry</label>
+    <select id="worldGeometry">
+      <option value="plane">Plane</option>
+      <option value="cube">Cube</option>
+      <option value="sphere">Sphere</option>
+    </select>
+    <label for="worldColor">World Colour</label>
+    <input type="color" id="worldColor" value="#00aaff" />
     <button id="loadBtn">Load Current Config</button>
     <button id="saveBtn">Save Config</button>
   </main>

--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -76,16 +76,22 @@ app.get('/config.js', (_req, res) => {
 });
 
 // In-memory world configuration. The admin page can fetch and update these
-// values via a small REST API guarded by a token header.
+// values via a small REST API guarded by a token header. Design properties such
+// as geometry and colour are included so the environment can be themed without
+// redeploying the server.
 interface WorldConfig {
   worldName: string;
   maxParticipants: number;
   welcomeMessage: string;
+  worldGeometry: string;
+  worldColor: string;
 }
 const worldConfig: WorldConfig = {
   worldName: 'Mingle World',
   maxParticipants: 20,
   welcomeMessage: 'Welcome to Mingle',
+  worldGeometry: 'plane',
+  worldColor: '#00aaff',
 };
 
 function verifyAdmin(req: express.Request, res: express.Response, next: express.NextFunction) {
@@ -105,7 +111,7 @@ if (ADMIN_TOKEN) {
   });
 
   app.post('/world-config', verifyAdmin, (req, res) => {
-    const { worldName, maxParticipants, welcomeMessage } = req.body;
+    const { worldName, maxParticipants, welcomeMessage, worldGeometry, worldColor } = req.body;
     if (typeof worldName === 'string') {
       worldConfig.worldName = worldName;
     }
@@ -114,6 +120,13 @@ if (ADMIN_TOKEN) {
     }
     if (typeof welcomeMessage === 'string') {
       worldConfig.welcomeMessage = welcomeMessage;
+    }
+    const allowedGeometries = ['plane', 'cube', 'sphere'];
+    if (typeof worldGeometry === 'string' && allowedGeometries.includes(worldGeometry)) {
+      worldConfig.worldGeometry = worldGeometry;
+    }
+    if (typeof worldColor === 'string' && /^#[0-9a-fA-F]{6}$/.test(worldColor)) {
+      worldConfig.worldColor = worldColor;
     }
     console.log('World configuration updated:', worldConfig);
     res.json({ status: 'ok' });


### PR DESCRIPTION
## Summary
- allow admins to choose world geometry and colour
- store world design properties on the server with validation
- document new configuration options in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a72bd27ea88328a1811e5b576b29aa