### PR TITLE
fix: enable mobile webcam playback

### DIFF
--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -493,7 +493,9 @@ socket.on('position', async data => {
     videoEl.id = `video-${data.id}`;
     videoEl.autoplay = true;
     videoEl.playsInline = true;
-    videoEl.muted = false; // allow remote audio playback; may require user gesture
+    // Mute video to satisfy mobile autoplay restrictions; remote audio is routed
+    // through a dedicated <audio> element for positional playback.
+    videoEl.muted = true;
     assetsEl.appendChild(videoEl);
 
     const front = document.createElement('a-plane');


### PR DESCRIPTION
## Summary
- ensure remote video elements are muted so mobile browsers auto-play streams

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a778bfac948328b583d4828bd0fc18