### PR TITLE
Add minimise toggle for instructions overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
   - Purpose: renders the main 3D meeting interface and surrounding UI chrome.
   - Structure:
     1. Page styling and navigation bar
-    2. On-screen usage instructions
+    2. On-screen usage instructions with minimise toggle
     3. Camera control sidebar with real-time status
     4. A-Frame scene setup with assets, cameras, avatar and spectate marker
        (local and remote avatars display webcam feeds via WebRTC)
@@ -74,6 +74,17 @@
       padding: 10px;
       z-index: 100;
     }
+    #instructionsToggle {
+      position: absolute;
+      top: 60px;
+      left: 10px;
+      background: rgba(0,0,0,0.6);
+      color: #fff;
+      border: none;
+      padding: 2px 6px;
+      cursor: pointer;
+      z-index: 101;
+    }
     #sidebar {
       position: fixed;
       top: 60px;
@@ -126,6 +137,7 @@
       </ul>
     </div>
   </nav>
+  <button id="instructionsToggle" aria-label="Hide instructions">&minus;</button>
   <div id="instructions">
     <p>Use WASD to move and mouse to look. Click to lock pointer.</p>
     <p>Use the profile button in the top-right to access account options.</p>

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -7,13 +7,14 @@
  *   1. Socket and DOM initialisation (unique player colour, random spawn,
  *      HTTPS warning)
  *   2. Debug logging helpers
- *   3. UI controls for spectating and fixed camera viewpoints
- *   4. Custom WASD movement handler and real-time status including participant
+ *   3. Instructions overlay toggle
+ *   4. UI controls for spectating and fixed camera viewpoints
+ *   5. Custom WASD movement handler and real-time status including participant
  *      count
- *   5. Webcam and microphone capture and playback
- *   6. WebRTC audio/video sharing between participants
- *   7. Periodic server synchronisation
- *   8. Remote avatar and spectate marker tracking
+ *   6. Webcam and microphone capture and playback
+ *   7. WebRTC audio/video sharing between participants
+ *   8. Periodic server synchronisation
+ *   9. Remote avatar and spectate marker tracking
 */
 
 // Establish socket connection to the server and cache DOM references.
@@ -30,6 +31,20 @@ const spectateMarker = document.getElementById('spectateMarker');
 const spectateToggle = document.getElementById('spectateToggle');
 const statusEl = document.getElementById('status');
 const viewpointRadios = document.querySelectorAll('input[name="viewpoint"]');
+const instructionsEl = document.getElementById('instructions');
+const instructionsToggle = document.getElementById('instructionsToggle');
+// Allow the instructions overlay to be minimised and restored.
+if (instructionsEl && instructionsToggle) {
+  instructionsToggle.addEventListener('click', () => {
+    const hidden = instructionsEl.style.display === 'none';
+    instructionsEl.style.display = hidden ? 'block' : 'none';
+    instructionsToggle.textContent = hidden ? '\u2212' : '+'; // minus/plus symbol
+    instructionsToggle.setAttribute('aria-label', hidden ? 'Hide instructions' : 'Show instructions');
+    debugLog(`Instructions ${hidden ? 'shown' : 'hidden'}`);
+  });
+} else {
+  debugError('Instructions toggle elements missing');
+}
 // Track which camera is currently rendering the view for status display.
 let activeCamera = playerCamera;
 // Track participant count for on-screen diagnostics.


### PR DESCRIPTION
## Summary
- Add dedicated button to hide or show on-screen instructions
- Wire up client logic to toggle the instructions overlay

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a77ad21904832880ed14919a84579a