### PR TITLE
Limit options overlay to mute and manual look

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   - Structure:
     1. Page styling and navigation bar
     2. On-screen usage instructions with minimise toggle
-    3. Camera control sidebar with real-time status
+    3. Options sidebar with microphone mute and manual look controls
     4. A-Frame scene setup with assets, cameras, avatar and spectate marker
        (local and remote avatars display webcam feeds via WebRTC)
     5. Client scripts for movement and navbar functionality
@@ -146,17 +146,8 @@
   </div>
 
   <aside id="sidebar">
-    <label><input type="checkbox" id="spectateToggle"> Spectate mode</label><br />
-    <label><input type="checkbox" id="muteToggle"> Mute microphone</label><br />
+    <label><input type="checkbox" id="muteToggle"> Mute microphone <span id="micStatus">(live)</span></label><br />
     <label><input type="checkbox" id="lookToggle"> Manual look</label><br />
-    <div id="micStatus">Mic: live</div>
-    <div>
-      <p>Viewpoint:</p>
-      <label><input type="radio" name="viewpoint" value="high" checked> High corner</label><br />
-      <label><input type="radio" name="viewpoint" value="ground"> Ground corner</label><br />
-      <label><input type="radio" name="viewpoint" value="top"> Top-down</label>
-    </div>
-    <div id="status"></div>
   </aside>
 
   <!-- Joystick containers positioned via CSS for touch navigation -->

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -8,7 +8,7 @@
  *      HTTPS warning)
  *   2. Debug logging helpers
  *   3. Instructions overlay toggle
- *   4. UI controls for spectating and fixed camera viewpoints
+ *   4. Spectating and fixed camera viewpoint logic (keyboard-driven)
  *   5. Custom WASD movement handler and real-time status including participant
  *      count
  *   6. Webcam and microphone capture and playback
@@ -305,7 +305,9 @@ function setSpectateMode(enabled) {
     }
     debugLog('Spectate mode disabled');
   }
-  spectateToggle.checked = spectating;
+  if (spectateToggle) {
+    spectateToggle.checked = spectating;
+  }
   updateStatus();
 }
 
@@ -334,6 +336,9 @@ function selectMode(mode) {
 }
 
 function updateStatus() {
+  if (!statusEl) {
+    return;
+  }
   if (!currentMode) {
     statusEl.textContent = `Mode: (initialising) | Users: ${connectedClients}`;
     return;
@@ -342,15 +347,17 @@ function updateStatus() {
   statusEl.textContent = `Mode: ${currentMode} | Camera: ${pos.x.toFixed(2)}, ${pos.y.toFixed(2)}, ${pos.z.toFixed(2)} | Users: ${connectedClients}`;
 }
 
-spectateToggle.addEventListener('change', () => {
-  if (currentMode === MODE_LAKITU) {
-    spectateToggle.checked = false; // spectating disabled in Lakitu mode
-    return;
-  }
-  setSpectateMode(spectateToggle.checked);
-  currentMode = spectating ? MODE_SPECTATOR : MODE_FPV;
-  updateStatus();
-});
+if (spectateToggle) {
+  spectateToggle.addEventListener('change', () => {
+    if (currentMode === MODE_LAKITU) {
+      spectateToggle.checked = false; // spectating disabled in Lakitu mode
+      return;
+    }
+    setSpectateMode(spectateToggle.checked);
+    currentMode = spectating ? MODE_SPECTATOR : MODE_FPV;
+    updateStatus();
+  });
+}
 viewpointRadios.forEach(radio => {
   radio.addEventListener('change', () => {
     if (radio.checked) {

--- a/public/js/ui_controls.js
+++ b/public/js/ui_controls.js
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // Display initial microphone state for clarity.
-  micStatus.textContent = 'Mic: live';
+  micStatus.textContent = '(live)';
 
   // Toggle the local audio track whenever the checkbox changes.
   muteToggle.addEventListener('change', () => {
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
       track.enabled = !muted;
     });
 
-    micStatus.textContent = muted ? 'Mic: muted' : 'Mic: live';
+    micStatus.textContent = muted ? '(muted)' : '(live)';
 
     if (typeof debugLog === 'function') {
       debugLog(`Microphone ${muted ? 'muted' : 'unmuted'}`);


### PR DESCRIPTION
## Summary
- Simplify options sidebar to only include microphone mute and manual look controls
- Guard spectate-related logic to handle absence of UI toggle
- Inline microphone status indicator with updated wording

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a78049d3f48328a3715415673cc191