### PR TITLE
feat: add webcam self preview

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,12 +6,13 @@
   - Structure:
     1. Page styling and navigation bar
     2. On-screen usage instructions with minimise toggle
-    3. Options sidebar with microphone mute and manual look controls
-    4. A-Frame scene setup with assets, cameras, avatar and spectate marker
+    3. Local webcam thumbnail with minimise button
+    4. Options sidebar with microphone mute and manual look controls
+    5. A-Frame scene setup with assets, cameras, avatar and spectate marker
        (local and remote avatars display webcam feeds via WebRTC)
        - Default GLB assets live in /public/assets and include a body and CRT TV
          model. The TV model's `screen` mesh is textured with the webcam feed.
-    5. Client scripts for movement and navbar functionality
+    6. Client scripts for movement and navbar functionality
   - Notes: A-Frame's default WASD controls are disabled on all cameras so that
     movement is handled exclusively by custom code in mingle_client.js.
 -->
@@ -89,7 +90,7 @@
     }
     #sidebar {
       position: fixed;
-      top: 60px;
+      top: 160px;
       right: 10px;
       width: 220px;
       background: rgba(255,255,255,0.9);
@@ -113,6 +114,40 @@
     }
     #moveJoystick { left: 0; bottom: 0; }
     #lookJoystick { right: 0; bottom: 0; display: none; }
+
+    /* Local webcam thumbnail positioned above the sidebar */
+    #selfPreview {
+      position: fixed;
+      top: 60px;
+      right: 10px;
+      width: 120px;
+      border: 2px solid #333;
+      background: #000;
+      z-index: 151;
+    }
+    #selfPreview video {
+      width: 100%;
+      display: block;
+    }
+    #selfPreview.hidden video {
+      display: none;
+    }
+    #selfPreviewToggle {
+      position: absolute;
+      top: 0;
+      right: 0;
+      background: rgba(0,0,0,0.6);
+      color: #fff;
+      border: none;
+      width: 20px;
+      height: 20px;
+      border-radius: 0 0 0 10px;
+      cursor: pointer;
+      font-weight: bold;
+    }
+    #selfPreview.hidden {
+      height: 20px;
+    }
   </style>
   <!--
     Load A-Frame and supporting libraries *before* the scene so that all
@@ -145,6 +180,11 @@
     <p>Use the profile button in the top-right to access account options.</p>
     <p>Allow microphone access when prompted so others can hear you. Use the mute control in the sidebar to silence yourself.</p>
     <p>On touch devices, a left thumbstick mirrors WASD movement. Enable Manual look to use a right thumbstick for camera pan/tilt.</p>
+  </div>
+
+  <div id="selfPreview">
+    <button id="selfPreviewToggle" aria-label="Hide webcam preview">&minus;</button>
+    <video id="selfPreviewVideo" autoplay playsinline muted></video>
   </div>
 
   <aside id="sidebar">
@@ -209,6 +249,7 @@
   <script src="js/mobile_controls.js"></script>
   <script src="js/webrtc.js"></script>
   <script src="js/ui_controls.js"></script>
+  <script src="js/webcam_preview.js"></script>
   <script src="js/mingle_navbar.js"></script>
 </body>
 </html>

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -66,6 +66,7 @@ const localStreamPromise = navigator.mediaDevices
   .then(stream => {
     localStream = stream;
     const videoEl = document.getElementById('localVideo');
+    const previewEl = document.getElementById('selfPreviewVideo');
 
     const audioTracks = stream.getAudioTracks();
     if (audioTracks.length > 0) {
@@ -74,10 +75,16 @@ const localStreamPromise = navigator.mediaDevices
       debugError('No audio tracks found in local stream');
     }
 
-    // Attach the stream to the video element. Muting allows autoplay which
-    // prevents the A-Frame loader from stalling waiting for the video.
-    videoEl.muted = true;
+    // Attach the stream to the asset video element and on-screen preview.
+    videoEl.muted = true; // ensure autoplay works without user interaction
     videoEl.srcObject = stream;
+    if (previewEl) {
+      previewEl.muted = true;
+      previewEl.srcObject = stream;
+      previewEl.play().catch(err => debugError('Preview playback failed', err));
+    } else {
+      debugError('Self-preview video element missing');
+    }
     videoEl.onloadeddata = () => {
       debugLog('Webcam video element loaded');
       // The scene is already visible because the default loading screen is

--- a/public/js/webcam_preview.js
+++ b/public/js/webcam_preview.js
@@ -1,0 +1,60 @@
+/**
+ * webcam_preview.js
+ * Mini README:
+ * - Purpose: manage the on-screen local webcam thumbnail and allow
+ *   users to hide or show their own feed.
+ * - Structure:
+ *   1. Wait for DOM readiness and cache required elements.
+ *   2. Attach the local MediaStream to the preview once available.
+ *   3. Toggle visibility via a minimise button with debug logging.
+ * - Notes: depends on mingle_client.js to initialise #localVideo.
+ */
+
+// Initialise preview behaviour when the document is ready.
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('selfPreview');
+  const toggle = document.getElementById('selfPreviewToggle');
+  const previewVideo = document.getElementById('selfPreviewVideo');
+  const localVideo = document.getElementById('localVideo');
+
+  // Validate essential elements exist.
+  if (!container || !toggle || !previewVideo || !localVideo) {
+    if (typeof debugError === 'function') {
+      debugError('Self-preview elements missing from DOM');
+    } else {
+      console.error('Self-preview elements missing from DOM');
+    }
+    return;
+  }
+
+  // Attach local stream to the thumbnail when ready.
+  function attachPreview() {
+    if (localVideo.srcObject && !previewVideo.srcObject) {
+      previewVideo.srcObject = localVideo.srcObject;
+      previewVideo.play().catch(err => {
+        if (typeof debugError === 'function') {
+          debugError('Preview playback failed', err);
+        } else {
+          console.error('Preview playback failed', err);
+        }
+      });
+    }
+  }
+
+  if (localVideo.srcObject) {
+    attachPreview();
+  } else {
+    localVideo.addEventListener('loadedmetadata', attachPreview);
+  }
+
+  // Toggle visibility via the minimise button.
+  toggle.addEventListener('click', () => {
+    container.classList.toggle('hidden');
+    const hidden = container.classList.contains('hidden');
+    toggle.textContent = hidden ? '+' : '\u2212';
+    toggle.setAttribute('aria-label', hidden ? 'Show webcam preview' : 'Hide webcam preview');
+    if (typeof debugLog === 'function') {
+      debugLog(`Self-preview ${hidden ? 'hidden' : 'shown'}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add on-screen webcam thumbnail with minimise toggle
- pipe local stream into thumbnail for instant feedback
- introduce dedicated script to manage preview visibility

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a84c71e7188328b1bb1141442aab9e