### PR TITLE
Refresh asset list after uploads

### DIFF
--- a/public/js/world_admin.js
+++ b/public/js/world_admin.js
@@ -160,6 +160,8 @@ async function uploadAsset(type) {
     const data = await res.json();
     adminDebugLog('Uploaded asset', data);
     alert('Asset uploaded');
+    // Immediately refresh the asset lists so new uploads appear without a page reload
+    await loadAssetsAndConfig();
   } catch (err) {
     console.error(err);
     alert('Upload failed');


### PR DESCRIPTION
## Summary
- Refresh admin asset lists immediately after uploading new GLB files so thumbnails for bodies and TVs update without a page reload.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a86a105cc0832896df9a9e339c378b