### PR TITLE
Fix FPV camera offset and restore webcam feed on avatars

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -221,19 +221,21 @@
     <a-entity light="type: ambient; intensity: 0.5"></a-entity>
     <a-entity light="type: directional; intensity: 0.8" position="0 1 1"></a-entity>
 
-    <!-- Player entity that holds the camera and avatar. Movement is handled by a
-         custom controller in mingle_client.js so we omit the built-in
-         `wasd-controls`. The avatar starts hidden so it does not obstruct the
-         first-person view but becomes visible in spectate mode. -->
-    <a-entity id="player" position="0 1.6 0">
-      <!-- The avatar now combines a body model with a CRT TV head. The TV's
+    <!-- Player entity rooted at ground level. The first-person camera sits at
+         the centre of the webcam screen so the FPV view aligns with the TV
+         head. Movement is handled by a custom controller in mingle_client.js so
+         we omit the built-in `wasd-controls`. The avatar starts hidden so it
+         does not obstruct the first-person view but becomes visible in spectate
+         mode. -->
+    <a-entity id="player" position="0 0 0">
+      <!-- The avatar combines a body model with a CRT TV head. The TV's
            `screen` mesh is dynamically textured with the user's webcam feed
            once the model loads. Remote participants mirror this layout. -->
-      <a-camera id="playerCamera" position="0 0 0" look-controls="pointerLockEnabled: true" wasd-controls="enabled: false"></a-camera>
+      <a-camera id="playerCamera" position="0 1.6 0" look-controls="pointerLockEnabled: true" wasd-controls="enabled: false"></a-camera>
       <a-entity id="avatar" position="0 0 0" visible="false">
         <!-- Model assignments occur in mingle_client.js once assets are loaded. -->
-        <a-entity id="avatarBody"></a-entity>
-        <a-entity id="avatarTV" position="0 0.8 0"></a-entity>
+        <a-entity id="avatarBody" position="0 0.8 0"></a-entity>
+        <a-entity id="avatarTV" position="0 1.6 0"></a-entity>
       </a-entity>
     </a-entity>
 


### PR DESCRIPTION
## Summary
- Anchor player at ground level and align first-person camera with TV head so FPV view originates from webcam screen
- Ensure video texture applies to fallback box models even when already loaded and adjust remote avatar assembly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a869d3384483289056cde4db4a9b0d