### PR TITLE
Persist avatar TV placement from world configuration

### DIFF
--- a/public/js/world_admin.js
+++ b/public/js/world_admin.js
@@ -43,6 +43,22 @@ async function loadConfig() {
     welcomeMessageInput.value = data.welcomeMessage;
     worldGeometrySelect.value = data.worldGeometry || 'plane';
     worldColorInput.value = data.worldColor || '#00aaff';
+    if (data.tvPosition) {
+      tvPosX.value = String(data.tvPosition.x);
+      tvPosY.value = String(data.tvPosition.y);
+      tvPosZ.value = String(data.tvPosition.z);
+    }
+    if (currentManifest) {
+      selectedBody = currentManifest.bodies.find(b => b.id === data.defaultBodyId) || null;
+      selectedTV = currentManifest.tvs.find(t => t.id === data.defaultTvId) || null;
+      if (selectedBody) {
+        bodyScaleRange.value = String(selectedBody.scale);
+      }
+      if (selectedTV) {
+        tvScaleRange.value = String(selectedTV.scale);
+      }
+      updatePreview();
+    }
     adminDebugLog('Loaded config', data);
   } catch (err) {
     console.error(err);
@@ -187,6 +203,10 @@ const tvPosY = document.getElementById('tvPosY');
 const tvPosZ = document.getElementById('tvPosZ');
 const savePlacementBtn = document.getElementById('savePlacementBtn');
 
+// Manifest of uploaded assets, populated when assets are loaded so the config
+// loader can match saved IDs to actual files.
+let currentManifest = null;
+
 let selectedBody = null;
 let selectedTV = null;
 let bodyMesh = null;
@@ -305,8 +325,8 @@ function renderAssetLists(manifest) {
 async function loadAssetsAndConfig() {
   try {
     const res = await fetch('/api/assets');
-    const manifest = await res.json();
-    renderAssetLists(manifest);
+    currentManifest = await res.json();
+    renderAssetLists(currentManifest);
   } catch (err) {
     console.error('Failed to load assets', err);
   }

--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -6,7 +6,7 @@
  * - Structure:
  *   1. Configuration flags (port, host, HTTPS, debug, admin token)
  *   2. Server creation (HTTP/HTTPS)
- *   3. Middleware, static routes and admin world config endpoints
+ *   3. Middleware, static routes and world config endpoints (public GET, admin POST)
  *   4. Socket.io events for position, participant count and WebRTC signalling
  *   5. Asset upload and listing endpoints for avatar models
  *   6. Startup logging with LAN-friendly addresses and HTTP/HTTPS guidance
@@ -161,11 +161,14 @@ function verifyAdmin(req: express.Request, res: express.Response, next: express.
   next();
 }
 
-if (ADMIN_TOKEN) {
-  app.get('/world-config', verifyAdmin, (_req, res) => {
-    res.json(worldConfig);
-  });
+// Always expose the current world configuration so clients can align default
+// assets and TV placement without an admin token. Admin-only modifications are
+// guarded separately below.
+app.get('/world-config', (_req, res) => {
+  res.json(worldConfig);
+});
 
+if (ADMIN_TOKEN) {
   app.post('/world-config', verifyAdmin, (req, res) => {
     const { worldName, maxParticipants, welcomeMessage, worldGeometry, worldColor, defaultBodyId, defaultTvId, tvPosition } = req.body;
     if (typeof worldName === 'string') {


### PR DESCRIPTION
## Summary
- expose world configuration to clients without admin token
- load default body/TV assets and saved TV offset on startup
- allow admin UI to restore saved asset selections and positions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a86d7cc6d88328a0badb17ce24177b