### PR TITLE
feat: show metadata for avatar assets

### DIFF
--- a/public/js/world_admin.js
+++ b/public/js/world_admin.js
@@ -256,6 +256,18 @@ async function deleteAsset(type, id) {
   }
 }
 
+function formatBytes(bytes) {
+  if (typeof bytes !== 'number') return 'unknown';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let i = 0;
+  let num = bytes;
+  while (num >= 1024 && i < units.length - 1) {
+    num /= 1024;
+    i++;
+  }
+  return `${num.toFixed(1)} ${units[i]}`;
+}
+
 function renderLists(manifest, config) {
   if (bodyList) bodyList.innerHTML = '';
   if (tvList) tvList.innerHTML = '';
@@ -268,8 +280,14 @@ function renderLists(manifest, config) {
     viewer.src = `/assets/${b.filename}`;
     viewer.style.width = '60px';
     viewer.style.height = '60px';
-    const info = document.createElement('span');
-    info.textContent = `${b.filename}`;
+    const info = document.createElement('div');
+    const name = document.createElement('span');
+    name.textContent = b.filename;
+    const meta = document.createElement('small');
+    const sizeText = formatBytes(b.size);
+    const uploadedText = b.uploaded ? new Date(b.uploaded).toLocaleString() : 'unknown date';
+    meta.textContent = `${sizeText} • ${uploadedText}`;
+    info.append(name, document.createElement('br'), meta);
     const radio = document.createElement('input');
     radio.type = 'radio';
     radio.name = 'bodySelect';
@@ -294,8 +312,14 @@ function renderLists(manifest, config) {
     viewer.src = `/assets/${t.filename}`;
     viewer.style.width = '60px';
     viewer.style.height = '60px';
-    const info = document.createElement('span');
-    info.textContent = `${t.filename}`;
+    const info = document.createElement('div');
+    const name = document.createElement('span');
+    name.textContent = t.filename;
+    const meta = document.createElement('small');
+    const sizeText = formatBytes(t.size);
+    const uploadedText = t.uploaded ? new Date(t.uploaded).toLocaleString() : 'unknown date';
+    meta.textContent = `${sizeText} • ${uploadedText}`;
+    info.append(name, document.createElement('br'), meta);
     const radio = document.createElement('input');
     radio.type = 'radio';
     radio.name = 'tvSelect';

--- a/public/world_admin.html
+++ b/public/world_admin.html
@@ -8,7 +8,7 @@
     1. Navbar reused across Mingle pages
     2. Instructional form for admin token and world configuration values
     3. Fields for world design (geometry and colour)
-    4. Avatar asset management: body and TV lists with upload/delete controls
+    4. Avatar asset management: body and TV lists with metadata, upload/delete controls
        plus a Three.js preview to align the TV and webcam canvas
     5. Client-side script to load and save settings via the secure API
   - Notes: requires the server to be started with ADMIN_TOKEN for access.

--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -120,6 +120,8 @@ interface AssetEntry {
   id: string;
   filename: string;
   scale: number;
+  size?: number; // file size in bytes
+  uploaded?: number; // unix epoch ms when uploaded
   screen?: { x: number; y: number; width: number; height: number };
 }
 interface AssetManifest {
@@ -240,6 +242,8 @@ if (ADMIN_TOKEN) {
       id: Date.now().toString(),
       filename: path.posix.join(subdir, req.file.filename),
       scale: parseFloat(scale) || 1,
+      size: req.file.size,
+      uploaded: Date.now(),
     };
     if (type === 'tv') {
       entry.screen = {


### PR DESCRIPTION
## Summary
- capture file size and upload date for avatar assets on upload
- display model metadata with thumbnail preview and selection controls on admin page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a87f6c31d88328b26759b0b840bba1