### PR TITLE
Fix asset manifest sync and admin upload buttons

### DIFF
--- a/public/world_admin.html
+++ b/public/world_admin.html
@@ -76,8 +76,8 @@
     </select>
     <label for="worldColor">World Colour</label>
     <input type="color" id="worldColor" value="#00aaff" />
-    <button id="loadBtn">Load Current Config</button>
-    <button id="saveBtn">Save Config</button>
+    <button id="loadBtn" type="button">Load Current Config</button>
+    <button id="saveBtn" type="button">Save Config</button>
 
     <h2>Avatar Assets</h2>
     <p>Select models, preview placement and adjust the webcam canvas. Admin token is required for uploads or deletions.</p>
@@ -92,7 +92,7 @@
         </table>
         <div style="margin-top:10px;">
           <input type="file" id="bodyFile" accept=".glb" />
-          <button id="uploadBodyBtn">Upload New Body</button>
+          <button id="uploadBodyBtn" type="button">Upload New Body</button>
         </div>
       </div>
       <div id="tvColumn" style="flex:1;">
@@ -105,7 +105,7 @@
         </table>
         <div style="margin-top:10px;">
           <input type="file" id="tvFile" accept=".glb" />
-          <button id="uploadTVBtn">Upload New TV</button>
+          <button id="uploadTVBtn" type="button">Upload New TV</button>
         </div>
       </div>
       <div id="previewColumn" style="flex:1;">
@@ -125,7 +125,7 @@
             <label>Cam Scale <input type="range" id="camScaleRange" min="0.1" max="5" step="0.1" value="1"></label>
           </div>
         </div>
-        <button id="savePlacementBtn" style="margin-top:10px;">Save and Update User Avatars</button>
+        <button id="savePlacementBtn" type="button" style="margin-top:10px;">Save and Update User Avatars</button>
       </div>
     </div>
     </main>


### PR DESCRIPTION
## Summary
- keep asset manifest synced with files added or removed from assets folders
- mark admin page buttons as type="button" to avoid unintended form submissions

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- started server and confirmed `/api/assets` detects new files added at runtime

------
https://chatgpt.com/codex/tasks/task_e_68a88d762d9c8328a485b6d8ada19a58