### PR TITLE
Fix admin asset upload and manifest sync

### DIFF
--- a/public/assets/README.md
+++ b/public/assets/README.md
@@ -6,8 +6,9 @@ Mini README:
   - `bodies/` – uploaded body models
   - `tvs/` – uploaded TV head models
   - `asset-manifest.json` – generated metadata describing available assets
-- **Notes:** Default models (`default-body.glb`, `default-tv.glb`) may be placed
-  directly in this directory if desired.
+- **Notes:** `.glb` files placed directly in this directory are automatically
+  detected. Name files with `tv` in the title (e.g. `default-tv.glb`) to have
+  them treated as TV models; all other root-level files are treated as bodies.
 
 Drop appropriately named files into the respective subdirectories or upload
 them via the admin panel. Metadata such as model scale and TV screen region are

--- a/public/js/world_admin.js
+++ b/public/js/world_admin.js
@@ -18,7 +18,7 @@ function adminDebugLog(...args) {
     console.log(...args);
   }
 }
-
+document.addEventListener('DOMContentLoaded', () => {
 const tokenInput = document.getElementById('token');
 const worldNameInput = document.getElementById('worldName');
 const maxParticipantsInput = document.getElementById('maxParticipants');
@@ -460,3 +460,4 @@ async function savePlacement() {
   }
 }
 if (savePlacementBtn) savePlacementBtn.addEventListener('click', savePlacement);
+});


### PR DESCRIPTION
## Summary
- detect `.glb` files placed directly in the asset folder so tables populate
- initialise admin page after DOM load for reliable upload button handlers
- document root-level asset support

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8976f30788328b23ebc42b01d4c7e