### PR TITLE
Fix default avatar geometry so webcam feed renders

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -236,8 +236,8 @@
         <!-- Model assignments occur in mingle_client.js once assets are loaded. -->
         <a-entity id="avatarBody" position="0 0.8 0"></a-entity>
         <a-entity id="avatarTV" position="0 1.6 0" geometry="primitive: box; height: 0.5; width: 0.5; depth: 0.5" material="color: #222222">
-          <!-- Placeholder plane for webcam feed; attributes set in mingle_client.js -->
-          <a-plane id="avatarWebcam" position="0 0 -0.251" width="0.5" height="0.5"></a-plane>
+          <!-- Placeholder plane for webcam feed sized and placed to match the front face -->
+          <a-plane id="avatarWebcam" position="0 0 0.251" width="0.5" height="0.5"></a-plane>
         </a-entity>
       </a-entity>
     </a-entity>

--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -164,8 +164,8 @@ let tvOffset = { x: 0, y: 1.6, z: 0 };
 let webcamOffset = {
   x: 0,
   y: 0,
-  // Negative z places the webcam feed on the front face rather than behind the cube.
-  z: -(FALLBACK_TV_SIZE / 2 + WEB_CAM_EPSILON),
+  // Positive z places the webcam feed on the forward face rather than inside the cube.
+  z: FALLBACK_TV_SIZE / 2 + WEB_CAM_EPSILON,
   scale: FALLBACK_TV_SIZE,
 };
 

--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -101,8 +101,12 @@ const worldConfig: WorldConfig = {
   worldColor: '#00aaff',
   defaultBodyId: undefined,
   defaultTvId: undefined,
-  tvPosition: { x: 0, y: 1, z: 0 },
-  webcamOffset: { x: 0, y: 0, z: 0.2, scale: 1 },
+  // Default placement for the simple fallback grey cuboid body and black TV
+  // head. The TV's centre sits exactly on top of the body so the head appears
+  // attached. The webcam plane is positioned slightly in front of the TV's
+  // forward (+Z) face so the video texture renders cleanly without z-fighting.
+  tvPosition: { x: 0, y: 1.6, z: 0 },
+  webcamOffset: { x: 0, y: 0, z: 0.251, scale: 0.5 },
 };
 
 // Avatar asset storage lives under /public/assets. Metadata about uploaded


### PR DESCRIPTION
## Summary
- place default TV head directly above body and size webcam canvas to match
- position webcam plane flush with TV front face so video is visible
- update client defaults to keep webcam plane on cube surface

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aac0c9b2788328a1191a7d5917f7a5