### PR TITLE
fix: enable asset previews by loading model-viewer as module

### DIFF
--- a/public/world_admin.html
+++ b/public/world_admin.html
@@ -131,7 +131,8 @@
     </main>
     <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/examples/js/loaders/GLTFLoader.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer.min.js"></script>
+    <!-- model-viewer is an ES module; load it accordingly so custom element renders previews -->
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer.min.js"></script>
     <script src="js/mingle_navbar.js"></script>
     <script src="js/world_admin.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- load model-viewer script as ES module so asset thumbnails and placement preview render

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aad202f84c8328b8a5663c499bfad4