### PR TITLE
fix: restore admin 3D preview loading

### DIFF
--- a/public/world_admin.html
+++ b/public/world_admin.html
@@ -131,16 +131,12 @@
     </main>
     <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
     <!--
-      Load GLTFLoader as an ES module and expose it on the global THREE
-      namespace. world_admin.js uses THREE.GLTFLoader for previewing uploaded
-      assets; if GLTFLoader is missing the preview silently fails. Attaching
-      the loader here ensures previewCanvas initialises correctly.
+      Load GLTFLoader from the CDN and attach it to the global THREE namespace.
+      Using the non-module version guarantees it executes before world_admin.js
+      so the Three.js preview initialises correctly even in environments without
+      module support.
     -->
-    <script type="module">
-      import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.152.2/examples/jsm/loaders/GLTFLoader.js';
-      window.THREE = window.THREE || {};
-      window.THREE.GLTFLoader = GLTFLoader;
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/examples/js/loaders/GLTFLoader.js"></script>
     <!-- model-viewer is an ES module; load it accordingly so custom element renders previews -->
     <script type="module" src="https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer.min.js"></script>
     <script src="js/mingle_navbar.js"></script>


### PR DESCRIPTION
## Summary
- load GLTFLoader from CDN as non-module script so admin preview initialises

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aad8fbba248328b3c1aa3481ad39c2