### PR TITLE
refactor: convert world admin script to ES module

### DIFF
--- a/public/js/world_admin.module.js
+++ b/public/js/world_admin.module.js
@@ -1,5 +1,5 @@
 /**
- * world_admin.js
+ * world_admin.module.js
  * Mini README:
  * - Purpose: handle world configuration form interactions for administrators,
  *   manage avatar asset uploads and placement.
@@ -12,7 +12,11 @@
  *   6. List uploaded assets with metadata, selection radios and delete controls
  *   7. Three.js preview for aligning TV and webcam canvas before saving
  * - Notes: requires the admin token set on the server. Token is provided via the form.
-*/
+ *         imports Three.js and GLTFLoader locally from `vendor` to work offline.
+ */
+import * as THREE from './vendor/three.module.js';
+import { GLTFLoader } from './vendor/GLTFLoader.js';
+
 function adminDebugLog(...args) {
   if (window.MINGLE_DEBUG) {
     console.log(...args);
@@ -140,18 +144,14 @@ let camera = null;
 let loader = null;
 function initThree() {
   if (!previewCanvas) return;
-  // Bail out early if the GLTFLoader dependency failed to load. Without this
-  // check `new THREE.GLTFLoader()` would throw and break the admin page.
-  if (!THREE || !THREE.GLTFLoader) {
-    throw new Error('GLTFLoader missing');
-  }
+  // Initialize Three.js renderer, scene and camera using locally vendored modules.
   renderer = new THREE.WebGLRenderer({ canvas: previewCanvas, alpha: true });
   scene = new THREE.Scene();
   camera = new THREE.PerspectiveCamera(45, previewCanvas.width / previewCanvas.height, 0.1, 100);
   camera.position.set(0, 1.5, 3);
   const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
   scene.add(light);
-  loader = new THREE.GLTFLoader();
+  loader = new GLTFLoader();
   function animate() {
     requestAnimationFrame(animate);
     renderer.render(scene, camera);

--- a/public/world_admin.html
+++ b/public/world_admin.html
@@ -13,7 +13,7 @@
     5. Client-side script to load and save settings via the secure API
   - Notes:
     - requires the server to be started with ADMIN_TOKEN for access
-    - loads Three.js (three.module.js) and GLTFLoader locally from `js/vendor`
+    - uses world_admin.module.js to import Three.js and GLTFLoader from `js/vendor`
       so the admin interface works without a CDN; update these with the curl
       commands listed in the project README when a newer release is needed
 -->
@@ -133,22 +133,9 @@
       </div>
     </div>
     </main>
-    <!--
-      Load vendored Three.js modules so the preview canvas renders even without
-      internet access. The modules are imported and re-attached to the global
-      namespace for compatibility with the rest of the admin script.
-    -->
-    <script type="module">
-      import * as THREE from './js/vendor/three.module.js';
-      import { GLTFLoader } from './js/vendor/GLTFLoader.js';
-      // Expose THREE and GLTFLoader globally for world_admin.js which expects
-      // them on the window object.
-      window.THREE = THREE;
-      window.THREE.GLTFLoader = GLTFLoader;
-    </script>
     <!-- model-viewer is an ES module; load it accordingly so custom element renders previews -->
     <script type="module" src="https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer.min.js"></script>
     <script src="js/mingle_navbar.js"></script>
-    <script src="js/world_admin.js"></script>
+    <script type="module" src="js/world_admin.module.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- convert `world_admin.js` into `world_admin.module.js` using native ES module imports for Three.js and GLTFLoader
- update world_admin.html to load the new module and remove obsolete global initialisation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab035894988328b5f6f0b618442577