### PR TITLE
Ensure admin asset table loads fresh manifest

### DIFF
--- a/public/js/world_admin.module.js
+++ b/public/js/world_admin.module.js
@@ -22,13 +22,18 @@ function adminDebugLog(...args) {
     console.log(...args);
   }
 }
-document.addEventListener('DOMContentLoaded', () => {
-const tokenInput = document.getElementById('token');
-const worldNameInput = document.getElementById('worldName');
-const maxParticipantsInput = document.getElementById('maxParticipants');
-const welcomeMessageInput = document.getElementById('welcomeMessage');
-const worldGeometrySelect = document.getElementById('worldGeometry');
-const worldColorInput = document.getElementById('worldColor');
+// Initialise the admin interface once the DOM is ready. Some environments
+// inject module scripts after `DOMContentLoaded` has already fired which would
+// previously prevent initialisation from running and the asset table from
+// populating. We now guard against that by explicitly checking the readyState
+// and running `init()` immediately if the document is already loaded.
+function init() {
+  const tokenInput = document.getElementById('token');
+  const worldNameInput = document.getElementById('worldName');
+  const maxParticipantsInput = document.getElementById('maxParticipants');
+  const welcomeMessageInput = document.getElementById('welcomeMessage');
+  const worldGeometrySelect = document.getElementById('worldGeometry');
+  const worldColorInput = document.getElementById('worldColor');
 
 async function loadConfig() {
   const token = tokenInput.value.trim();
@@ -167,7 +172,7 @@ try {
 }
 
 // Load manifest and config whether or not the preview initializes successfully.
-loadAssetsAndConfig();
+  loadAssetsAndConfig();
 
 async function ensureVideoTexture() {
   if (videoTexture) return videoTexture;
@@ -510,4 +515,11 @@ async function savePlacement() {
   }
 }
 if (savePlacementBtn) savePlacementBtn.addEventListener('click', savePlacement);
-});
+}
+
+// Run `init` as soon as the DOM is available.
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -431,8 +431,13 @@ if (ADMIN_TOKEN) {
   console.warn('ADMIN_TOKEN not set; admin endpoints disabled');
 }
 
+// Expose the current asset manifest and explicitly disable caching so that
+// newly added or removed models are reflected immediately on subsequent page
+// loads. The manifest is re-synchronised with the filesystem on each request.
 app.get('/api/assets', (_req, res) => {
-  res.json(readManifest());
+  const manifest = readManifest();
+  res.set('Cache-Control', 'no-store');
+  res.json(manifest);
 });
 
 interface PositionData {


### PR DESCRIPTION
## Summary
- Initialise world admin UI immediately if the page is already loaded so asset lists always render
- Return asset manifest with `Cache-Control: no-store` to prevent stale caching

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `curl -i http://localhost:3000/api/assets`


------
https://chatgpt.com/codex/tasks/task_e_68ab352b30808328bd60378280e4c8e3