### PR TITLE
feat: add on-page debug log for preview errors

### DIFF
--- a/public/js/world_admin.module.js
+++ b/public/js/world_admin.module.js
@@ -4,7 +4,7 @@
  * - Purpose: handle world configuration form interactions for administrators,
  *   manage avatar asset uploads and placement.
  * - Structure:
- *   1. Helper debug logger
+ *   1. Helper debug logger and on-page debug log
  *   2. Load existing config when requested
  *   3. Submit updates back to the server
  *   4. Handle world design (geometry and colour) fields
@@ -34,6 +34,7 @@ function init() {
   const welcomeMessageInput = document.getElementById('welcomeMessage');
   const worldGeometrySelect = document.getElementById('worldGeometry');
   const worldColorInput = document.getElementById('worldColor');
+  const debugLog = document.getElementById('debugLog'); // Div to surface detailed errors for admins
 
 async function loadConfig() {
   const token = tokenInput.value.trim();
@@ -163,11 +164,19 @@ function initThree() {
   }
   animate();
 }
-// Attempt to start the 3D preview, but allow the page to continue even if it fails.
+// Attempt to start the 3D preview. On failure, log details to the debug area so
+// admins can diagnose issues such as unreachable CDNs or CSP blocks.
 try {
   initThree();
 } catch (err) {
-  adminDebugLog('Preview initialization failed', err);
+  const message = `Preview initialization failed: ${err.message}`;
+  const stack = err.stack || 'No stack available';
+  const guidance = 'Typical causes: CDN unreachable or CSP restrictions blocking script execution.';
+  if (debugLog) {
+    if (debugLog.textContent === 'No errors logged.') debugLog.textContent = '';
+    debugLog.textContent += `${message}\n${stack}\n${guidance}\n`;
+  }
+  adminDebugLog(message, err);
   alert('Preview could not start. You can still upload assets.');
 }
 

--- a/public/world_admin.html
+++ b/public/world_admin.html
@@ -11,6 +11,7 @@
     4. Avatar asset management: body and TV tables with metadata, upload/delete controls
        plus a Three.js preview to align the TV and webcam canvas
     5. Client-side script to load and save settings via the secure API
+    6. Debug log area (#debugLog) surfaces script errors and typical causes
   - Notes:
     - requires the server to be started with ADMIN_TOKEN for access
     - loads Three.js and GLTFLoader from local `js/vendor` paths with error
@@ -129,10 +130,12 @@
             <label>Cam Scale <input type="range" id="camScaleRange" min="0.1" max="5" step="0.1" value="1"></label>
           </div>
         </div>
-        <button id="savePlacementBtn" type="button" style="margin-top:10px;">Save and Update User Avatars</button>
+    <button id="savePlacementBtn" type="button" style="margin-top:10px;">Save and Update User Avatars</button>
       </div>
     </div>
-    </main>
+    <h2>Debug Log</h2>
+      <div id="debugLog" style="white-space: pre-wrap; background:#f9f9f9; border:1px solid #ccc; padding:10px; margin-top:20px;">No errors logged.</div>
+      </main>
     <!-- model-viewer is an ES module; load it accordingly so custom element renders previews -->
     <script type="module" src="https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer.min.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- add visible debug log area on world admin page
- log preview initialization errors with stack trace and guidance for common issues
- document new debug aid in inline comments

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab3dc0209c8328a0a592066ac1e35c