### PR TITLE
Fix webcam plane orientation on default head

### DIFF
--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -164,8 +164,8 @@ let tvOffset = { x: 0, y: 1.6, z: 0 };
 let webcamOffset = {
   x: 0,
   y: 0,
-  // Positive z places the webcam feed on the forward face rather than inside the cube.
-  z: FALLBACK_TV_SIZE / 2 + WEB_CAM_EPSILON,
+  // Negative z places the webcam feed on the forward (-Z) face rather than inside the cube.
+  z: -(FALLBACK_TV_SIZE / 2 + WEB_CAM_EPSILON),
   scale: FALLBACK_TV_SIZE,
 };
 

--- a/public/world_admin.html
+++ b/public/world_admin.html
@@ -126,7 +126,7 @@
           <div>
             <label>Cam X <input type="range" id="camPosX" min="-1" max="1" step="0.01" value="0"></label>
             <label>Cam Y <input type="range" id="camPosY" min="-1" max="1" step="0.01" value="0"></label>
-            <label>Cam Z <input type="range" id="camPosZ" min="-1" max="1" step="0.01" value="0.2"></label>
+            <label>Cam Z <input type="range" id="camPosZ" min="-1" max="1" step="0.01" value="-0.25"></label>
             <label>Cam Scale <input type="range" id="camScaleRange" min="0.1" max="5" step="0.1" value="1"></label>
           </div>
         </div>

--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -105,9 +105,9 @@ const worldConfig: WorldConfig = {
   // Default placement for the simple fallback grey cuboid body and black TV
   // head. The TV's centre sits exactly on top of the body so the head appears
   // attached. The webcam plane is positioned slightly in front of the TV's
-  // forward (+Z) face so the video texture renders cleanly without z-fighting.
+  // forward (-Z) face so the video texture renders cleanly without z-fighting.
   tvPosition: { x: 0, y: 1.6, z: 0 },
-  webcamOffset: { x: 0, y: 0, z: 0.251, scale: 0.5 },
+  webcamOffset: { x: 0, y: 0, z: -0.251, scale: 0.5 },
 };
 
 // Avatar asset storage lives under /public/assets. Metadata about uploaded


### PR DESCRIPTION
## Summary
- ensure default webcam canvas renders on front (-Z) of fallback TV head
- update admin page default to match new forward direction
- adjust server world config to place webcam plane on front face

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab4fb4813c8328a31d277125d96f90