### PR TITLE
feat: add body placement controls and preview camera

### DIFF
--- a/public/world_admin.html
+++ b/public/world_admin.html
@@ -9,7 +9,7 @@
     2. Instructional form for admin token and world configuration values
     3. Fields for world design (geometry and colour)
     4. Avatar asset management: body and TV tables with metadata, upload/delete controls
-       plus a Three.js preview to align the TV and webcam canvas
+       plus a Three.js preview to align body, TV and webcam canvas with zoom/drag controls
     5. Client-side script to load and save settings via the secure API
     6. Debug log area (#debugLog) surfaces script errors and typical causes
   - Notes:
@@ -117,6 +117,12 @@
         <h3>Preview & Placement</h3>
         <canvas id="previewCanvas" width="400" height="400" style="border:1px solid #ccc;"></canvas>
         <div id="sliderColumns" style="display:flex; gap:10px; margin-top:10px;">
+          <div>
+            <label>Body X <input type="range" id="bodyPosX" min="-2" max="2" step="0.01" value="0"></label>
+            <label>Body Y <input type="range" id="bodyPosY" min="-2" max="2" step="0.01" value="0.8"></label>
+            <label>Body Z <input type="range" id="bodyPosZ" min="-2" max="2" step="0.01" value="0"></label>
+            <label>Body Scale <input type="range" id="bodyScaleRange" min="0.1" max="5" step="0.1" value="1"></label>
+          </div>
           <div>
             <label>TV X <input type="range" id="tvPosX" min="-2" max="2" step="0.01" value="0"></label>
             <label>TV Y <input type="range" id="tvPosY" min="-2" max="2" step="0.01" value="1"></label>

--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -91,6 +91,7 @@ interface WorldConfig {
   worldColor: string;
   defaultBodyId?: string;
   defaultTvId?: string;
+  bodyPosition?: { x: number; y: number; z: number };
   tvPosition?: { x: number; y: number; z: number };
   webcamOffset?: { x: number; y: number; z: number; scale: number };
 }
@@ -102,10 +103,12 @@ const worldConfig: WorldConfig = {
   worldColor: '#00aaff',
   defaultBodyId: undefined,
   defaultTvId: undefined,
+  bodyPosition: { x: 0, y: 0.8, z: 0 },
   // Default placement for the simple fallback grey cuboid body and black TV
-  // head. The TV's centre sits exactly on top of the body so the head appears
-  // attached. The webcam plane is positioned slightly in front of the TV's
-  // forward (+Z) face so the video texture renders cleanly without z-fighting.
+  // head. `bodyPosition` offsets the body so its feet rest on the ground. The
+  // TV's centre sits exactly on top of the body so the head appears attached.
+  // The webcam plane is positioned slightly in front of the TV's forward (+Z)
+  // face so the video texture renders cleanly without z-fighting.
   tvPosition: { x: 0, y: 1.6, z: 0 },
   webcamOffset: { x: 0, y: 0, z: 0.251, scale: 0.5 },
 };
@@ -290,7 +293,7 @@ app.get('/world-config', (_req, res) => {
 
 if (ADMIN_TOKEN) {
   app.post('/world-config', verifyAdmin, (req, res) => {
-    const { worldName, maxParticipants, welcomeMessage, worldGeometry, worldColor, defaultBodyId, defaultTvId, tvPosition, webcamOffset } = req.body;
+    const { worldName, maxParticipants, welcomeMessage, worldGeometry, worldColor, defaultBodyId, defaultTvId, bodyPosition, tvPosition, webcamOffset } = req.body;
     if (typeof worldName === 'string') {
       worldConfig.worldName = worldName;
     }
@@ -312,6 +315,14 @@ if (ADMIN_TOKEN) {
     }
     if (typeof defaultTvId === 'string') {
       worldConfig.defaultTvId = defaultTvId;
+    }
+    if (bodyPosition && typeof bodyPosition === 'object') {
+      const { x, y, z } = bodyPosition;
+      worldConfig.bodyPosition = {
+        x: typeof x === 'number' ? x : worldConfig.bodyPosition?.x || 0,
+        y: typeof y === 'number' ? y : worldConfig.bodyPosition?.y || 0,
+        z: typeof z === 'number' ? z : worldConfig.bodyPosition?.z || 0,
+      };
     }
     if (tvPosition && typeof tvPosition === 'object') {
       const { x, y, z } = tvPosition;


### PR DESCRIPTION
## Summary
- let admins position and scale body models with new sliders
- enable drag-orbit and scroll-wheel zoom on the preview canvas
- persist body placement to world config and apply offsets on clients

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab4f4e4e9883288283f02130d16f0a