### PR TITLE
Ensure webcam plane renders in front of avatar TV head

### DIFF
--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -164,8 +164,8 @@ let tvOffset = { x: 0, y: 1.6, z: 0 };
 let webcamOffset = {
   x: 0,
   y: 0,
-  // Negative z places the webcam feed on the forward (-Z) face rather than inside the cube.
-  z: -(FALLBACK_TV_SIZE / 2 + WEB_CAM_EPSILON),
+  // Positive z places the webcam feed slightly in front of the TV's face so it remains visible.
+  z: FALLBACK_TV_SIZE / 2 + WEB_CAM_EPSILON,
   scale: FALLBACK_TV_SIZE,
 };
 
@@ -188,6 +188,13 @@ async function initDefaultAssets() {
     }
     if (config.webcamOffset) {
       webcamOffset = config.webcamOffset;
+    }
+    // Ensure the webcam plane sits just outside the TV surface. A positive Z offset keeps
+    // the video texture in front of the head cube and avoids it rendering inside the mesh.
+    const halfDepth = (webcamOffset.scale || FALLBACK_TV_SIZE) / 2;
+    webcamOffset.z = Math.abs(webcamOffset.z);
+    if (webcamOffset.z < halfDepth + WEB_CAM_EPSILON) {
+      webcamOffset.z = halfDepth + WEB_CAM_EPSILON;
     }
     if (config.defaultBodyId) {
       defaultBodyEntry = manifest.bodies.find(b => b.id === config.defaultBodyId) || null;

--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -105,9 +105,9 @@ const worldConfig: WorldConfig = {
   // Default placement for the simple fallback grey cuboid body and black TV
   // head. The TV's centre sits exactly on top of the body so the head appears
   // attached. The webcam plane is positioned slightly in front of the TV's
-  // forward (-Z) face so the video texture renders cleanly without z-fighting.
+  // forward (+Z) face so the video texture renders cleanly without z-fighting.
   tvPosition: { x: 0, y: 1.6, z: 0 },
-  webcamOffset: { x: 0, y: 0, z: -0.251, scale: 0.5 },
+  webcamOffset: { x: 0, y: 0, z: 0.251, scale: 0.5 },
 };
 
 // Avatar asset storage lives under /public/assets. Metadata about uploaded


### PR DESCRIPTION
## Summary
- position local webcam plane slightly in front of TV surface to keep feed visible
- normalise and clamp webcam offsets from world config
- update server defaults and comments for correct orientation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab50ef18b88328b86a4a31a38002e1