### PR TITLE
feat: add webcam rotation controls

### DIFF
--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -170,6 +170,8 @@ let webcamOffset = {
   scale: FALLBACK_TV_SIZE,
 };
 let tvRotation = { x: 0, y: 0, z: 0 };
+// Allow rotating the webcam plane relative to the TV head for custom layouts.
+let webcamRotation = { x: 0, y: 0, z: 0 };
 
 /**
  * Fetch world configuration and asset manifest to determine which body and TV
@@ -196,6 +198,9 @@ async function initDefaultAssets() {
     }
     if (config.webcamOffset) {
       webcamOffset = config.webcamOffset;
+    }
+    if (config.webcamRotation) {
+      webcamRotation = config.webcamRotation;
     }
     // Ensure the webcam plane sits just outside the TV surface. A positive Z offset keeps
     // the video texture in front of the head cube and avoids it rendering inside the mesh.
@@ -283,6 +288,7 @@ async function initDefaultAssets() {
     avatarWebcam.setAttribute('position', `${webcamOffset.x} ${webcamOffset.y} ${webcamOffset.z}`);
     avatarWebcam.setAttribute('width', webcamOffset.scale);
     avatarWebcam.setAttribute('height', webcamOffset.scale);
+    avatarWebcam.setAttribute('rotation', `${webcamRotation.x} ${webcamRotation.y} ${webcamRotation.z}`);
   }
 }
 
@@ -717,6 +723,7 @@ socket.on('position', async data => {
     camPlane.setAttribute('position', `${webcamOffset.x} ${webcamOffset.y} ${webcamOffset.z}`);
     camPlane.setAttribute('width', webcamOffset.scale);
     camPlane.setAttribute('height', webcamOffset.scale);
+    camPlane.setAttribute('rotation', `${webcamRotation.x} ${webcamRotation.y} ${webcamRotation.z}`);
     camPlane.setAttribute('material', `shader: flat; src: #video-${data.id}`);
     tv.appendChild(camPlane);
 

--- a/public/world_admin.html
+++ b/public/world_admin.html
@@ -149,6 +149,18 @@
             <label>Cam Z <input type="range" id="camPosZ" min="-1" max="1" step="0.01" value="-0.25"></label>
             <!-- Allow broader scaling of the webcam canvas for atypical layouts -->
             <label>Cam Scale <input type="range" id="camScaleRange" min="0.01" max="20" step="0.01" value="1"></label>
+            <label>Cam Rot X
+              <input type="range" id="camRotX" min="-180" max="180" step="1" value="0">
+              <input type="number" id="camRotXNum" min="-180" max="180" step="1" value="0" style="width:60px;">
+            </label>
+            <label>Cam Rot Y
+              <input type="range" id="camRotY" min="-180" max="180" step="1" value="0">
+              <input type="number" id="camRotYNum" min="-180" max="180" step="1" value="0" style="width:60px;">
+            </label>
+            <label>Cam Rot Z
+              <input type="range" id="camRotZ" min="-180" max="180" step="1" value="0">
+              <input type="number" id="camRotZNum" min="-180" max="180" step="1" value="0" style="width:60px;">
+            </label>
           </div>
         </div>
     <button id="savePlacementBtn" type="button" style="margin-top:10px;">Save and Update User Avatars</button>

--- a/src/mingle_server.ts
+++ b/src/mingle_server.ts
@@ -95,6 +95,7 @@ interface WorldConfig {
   tvPosition?: { x: number; y: number; z: number };
   tvRotation?: { x: number; y: number; z: number };
   webcamOffset?: { x: number; y: number; z: number; scale: number };
+  webcamRotation?: { x: number; y: number; z: number };
 }
 const worldConfig: WorldConfig = {
   worldName: 'Mingle World',
@@ -117,6 +118,9 @@ const worldConfig: WorldConfig = {
   tvPosition: { x: 0, y: 1.6, z: 0 },
   tvRotation: { x: 0, y: 0, z: 0 },
   webcamOffset: { x: 0, y: 0, z: 0.251, scale: 0.5 },
+  // Rotation applied to the webcam plane (degrees) so feeds can be aligned
+  // with custom TV models or corrected when sources appear flipped.
+  webcamRotation: { x: 0, y: 0, z: 0 },
 };
 
 // Avatar asset storage lives under /public/assets. Metadata about uploaded
@@ -312,7 +316,7 @@ app.get('/world-config', (_req, res) => {
 
 if (ADMIN_TOKEN) {
   app.post('/world-config', verifyAdmin, (req, res) => {
-    const { worldName, maxParticipants, welcomeMessage, worldGeometry, worldColor, defaultBodyId, defaultTvId, bodyPosition, tvPosition, tvRotation, webcamOffset } = req.body;
+    const { worldName, maxParticipants, welcomeMessage, worldGeometry, worldColor, defaultBodyId, defaultTvId, bodyPosition, tvPosition, tvRotation, webcamOffset, webcamRotation } = req.body;
     if (typeof worldName === 'string') {
       worldConfig.worldName = worldName;
     }
@@ -366,6 +370,14 @@ if (ADMIN_TOKEN) {
         y: typeof y === 'number' ? y : worldConfig.webcamOffset?.y || 0,
         z: typeof z === 'number' ? z : worldConfig.webcamOffset?.z || 0,
         scale: typeof scale === 'number' ? scale : worldConfig.webcamOffset?.scale || 1,
+      };
+    }
+    if (webcamRotation && typeof webcamRotation === 'object') {
+      const { x, y, z } = webcamRotation;
+      worldConfig.webcamRotation = {
+        x: typeof x === 'number' ? x : worldConfig.webcamRotation?.x || 0,
+        y: typeof y === 'number' ? y : worldConfig.webcamRotation?.y || 0,
+        z: typeof z === 'number' ? z : worldConfig.webcamRotation?.z || 0,
       };
     }
     console.log('World configuration updated:', worldConfig);


### PR DESCRIPTION
## Summary
- allow rotating webcam plane via new `webcamRotation` world config property
- expose camera rotation sliders in world admin interface
- apply rotation to local and remote webcam feeds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6afaf4548328a34a6214b708b6ff