### PR TITLE
feat: add avatar preset system

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -182,6 +182,8 @@
     <p>Use the profile button in the top-right to access account options.</p>
     <p>Allow microphone access when prompted so others can hear you. Use the mute control in the sidebar to silence yourself.</p>
     <p>On touch devices, a left thumbstick mirrors WASD movement. Enable Manual look to use a right thumbstick for camera pan/tilt.</p>
+    <label for="avatarPresetSelect">Choose avatar:</label>
+    <select id="avatarPresetSelect"></select>
   </div>
 
   <div id="selfPreview">

--- a/public/world_admin.html
+++ b/public/world_admin.html
@@ -167,9 +167,22 @@
     <button id="savePlacementBtn" type="button" style="margin-top:10px;">Save and Update User Avatars</button>
       </div>
     </div>
-    <h2>Debug Log</h2>
-      <div id="debugLog" style="white-space: pre-wrap; background:#f9f9f9; border:1px solid #ccc; padding:10px; margin-top:20px;">No errors logged.</div>
-      </main>
+  <h2>Avatar Presets</h2>
+    <p>Store common body/TV layouts for quick avatar selection. Select a preset to edit or remove.</p>
+    <div style="margin-bottom:10px;">
+      <input type="text" id="presetName" placeholder="Preset name" />
+      <button id="savePresetBtn" type="button">Save/Update Preset</button>
+      <button id="newPresetBtn" type="button">New Preset</button>
+    </div>
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Body</th><th>TV</th><th>Edit</th><th>Delete</th></tr>
+      </thead>
+      <tbody id="presetTableBody"></tbody>
+    </table>
+  <h2>Debug Log</h2>
+    <div id="debugLog" style="white-space: pre-wrap; background:#f9f9f9; border:1px solid #ccc; padding:10px; margin-top:20px;">No errors logged.</div>
+    </main>
     <!-- model-viewer is an ES module; load it accordingly so custom element renders previews -->
     <script type="module" src="https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer.min.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- allow admins to save, update and delete avatar assemblies
- show available presets to users for quick avatar selection
- broadcast preset changes and per-user selections to all clients

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab7003d47c8328bfdf3176b43c5b78