### PR TITLE
Fix avatar dropdown closing when clicked

### DIFF
--- a/public/js/mingle_client.js
+++ b/public/js/mingle_client.js
@@ -206,6 +206,24 @@ async function initDefaultAssets(presetId) {
       presetSelect.addEventListener('change', () => {
         applyPreset(presetSelect.value);
       });
+      // Prevent pointer lock from immediately closing the dropdown by
+      // absorbing pointer events and pausing look-controls while the
+      // selector is focused. This keeps the avatar menu open long
+      // enough for a selection to be made.
+      presetSelect.addEventListener('pointerdown', evt => {
+        evt.stopPropagation();
+        if (document.pointerLockElement) {
+          document.exitPointerLock();
+        }
+        const lc = playerCamera.components['look-controls'];
+        if (lc) lc.pause();
+        debugLog('Avatar preset selector focused');
+      });
+      presetSelect.addEventListener('blur', () => {
+        const lc = playerCamera.components['look-controls'];
+        if (lc) lc.play();
+        debugLog('Avatar preset selector blurred');
+      });
     }
     // Determine which preset to use: specified id or first available.
     const chosenId = presetId || (presetSelect ? presetSelect.value : null);


### PR DESCRIPTION
## Summary
- prevent scene pointer lock from closing the avatar selector dropdown
- log focus changes for easier debugging

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab82310f6483289bcf84f754150431